### PR TITLE
Moved collision checkers

### DIFF
--- a/TheOneEngine/CollisionSolver.h
+++ b/TheOneEngine/CollisionSolver.h
@@ -13,6 +13,9 @@ public:
 	CollisionSolver();
 	~CollisionSolver();
 
+	bool PreUpdate();
+	bool Update(double dt);
+
 	bool CheckCollision(GameObject* objA, GameObject* objB);
 
 

--- a/TheOneEngine/EngineCore.cpp
+++ b/TheOneEngine/EngineCore.cpp
@@ -37,133 +37,15 @@ void EngineCore::Start()
 
 bool EngineCore::PreUpdate()
 {
-    return inputManager->PreUpdate();
+    inputManager->PreUpdate();
+    collisionSolver->PreUpdate();
+    return true;
 }
 
 void EngineCore::Update(double dt)
 {
-    //first, lets see the collider component still exists
-    for (auto it = collisionSolver->goWithCollision.begin(); it != collisionSolver->goWithCollision.end(); )
-    {
-        bool remItem = true;
-        for (auto& item2 : (*it)->GetAllComponents())
-        {
-            if (item2->GetType() == ComponentType::Collider2D) remItem = false;
-        }
-        if (remItem)
-        {
-            it = collisionSolver->goWithCollision.erase(it);
-        }
-        else
-        {
-            ++it;
-        }
-    }
-
-    //now lets check and solve collisions
-    if (/*app->state == GameState::PLAY || app->state == GameState::PLAY_ONCE*/true)
-    {
-        for (auto& item : collisionSolver->goWithCollision)
-        {
-            // Collision solving
-            switch (item->GetComponent<Collider2D>()->collisionType)
-            {
-            case CollisionType::Player:
-                for (auto& item2 : collisionSolver->goWithCollision)
-                {
-                    if (item != item2)
-                    {
-                        switch (item2->GetComponent<Collider2D>()->collisionType)
-                        {
-                        case CollisionType::Player:
-                            //there is no player-player collision since we only have 1 player
-                            break;
-                        case CollisionType::Enemy:
-                            //implement any low life to player
-                            break;
-                        case CollisionType::Wall:
-                            //if they collide
-                            if (collisionSolver->CheckCollision(item, item2))
-                            {
-                                //we push player out of wall
-                                collisionSolver->SolveCollision(item, item2);
-                            }
-                            break;
-                        default:
-                            break;
-                        }
-                    }
-                }
-                break;
-            case CollisionType::Enemy:
-                for (auto& item2 : collisionSolver->goWithCollision)
-                {
-                    if (item != item2)
-                    {
-                        switch (item2->GetComponent<Collider2D>()->collisionType)
-                        {
-                        case CollisionType::Player:
-                            //implement any low life to player
-                            break;
-                        case CollisionType::Enemy:
-                            //if they collide
-                            if (collisionSolver->CheckCollision(item, item2))
-                            {
-                                //we push player out of other enemy
-                                collisionSolver->SolveCollision(item, item2);
-                            }
-                            break;
-                        case CollisionType::Wall:
-                            //if they collide
-                            if (collisionSolver->CheckCollision(item, item2))
-                            {
-                                //we push enemy out of wall
-                                collisionSolver->SolveCollision(item, item2);
-                            }
-                            break;
-                        default:
-                            break;
-                        }
-                    }
-                }
-                break;
-            case CollisionType::Wall:
-                // do nothing at all
-                break;
-            case CollisionType::Bullet:
-                for (auto& item2 : collisionSolver->goWithCollision)
-                {
-                    if (item != item2)
-                    {
-                        switch (item2->GetComponent<Collider2D>()->collisionType)
-                        {
-                        case CollisionType::Player:
-                            if (collisionSolver->CheckCollision(item, item2))
-                            {
-                                LOG(LogType::LOG_WARNING, "Player Hit");
-                                item->AddToDelete(engine->N_sceneManager->objectsToDelete);
-                            }
-                            break;
-                        case CollisionType::Enemy:
-                            //if they collide
-                            if (collisionSolver->CheckCollision(item, item2))
-                            {
-                                MonoManager::CallScriptFunction(item2->GetComponent<Script>()->monoBehaviourInstance, "ReduceLife");
-                                item->AddToDelete(engine->N_sceneManager->objectsToDelete);
-                            }
-                            break;
-                        default:
-                            break;
-                        }
-                    }
-                }
-                break;
-            default:
-                break;
-            }
-        }
-    }
-
+    
+    collisionSolver->Update(dt);
     audioManager->Update(dt);
 
     this->dt = dt;


### PR DESCRIPTION
- The checkers and solvers of the collisions where done in the EngineCore->Update, now , enginge core update and preupdate call new collisionSolver-> preupdate and update, and the checkers and solvers are now directly in collisionSolver

BUGS? : when im on scene MainMenu, play the scene, inside the scene click play (start game or whatever it is), it crashes, i think that bug already existed, but just in case im saying it
![Captura de pantalla 2023-10-21 232924](https://github.com/Shadow-Wizard-Games/TheOneEngine/assets/99800056/61f89481-3bd3-4090-9abd-f6ccb487c918)
