### PR TITLE
Develop fix crash

### DIFF
--- a/TheOneEditor/Assets/Prefabs/UI_Manager.prefab
+++ b/TheOneEditor/Assets/Prefabs/UI_Manager.prefab
@@ -31,7 +31,7 @@
       "UID": 2371490470
     },
     {
-      "AudioID": 7,
+      "AudioID": 24,
       "Name": "AudioSource",
       "Type": 8
     }
@@ -1132,7 +1132,7 @@
           "UID": 951121546
         },
         {
-          "AudioID": 8,
+          "AudioID": 25,
           "Name": "AudioSource",
           "Type": 8
         }
@@ -1433,7 +1433,7 @@
           ]
         },
         {
-          "AudioID": 9,
+          "AudioID": 26,
           "Name": "Source",
           "Type": 8
         },
@@ -2998,7 +2998,7 @@
           "UID": 607510851
         },
         {
-          "AudioID": 10,
+          "AudioID": 27,
           "Name": "AudioSource",
           "Type": 8
         }
@@ -3497,7 +3497,7 @@
           ]
         },
         {
-          "AudioID": 11,
+          "AudioID": 28,
           "Name": "AudioSource",
           "Type": 8
         }
@@ -3681,7 +3681,7 @@
           ]
         },
         {
-          "AudioID": 12,
+          "AudioID": 29,
           "Name": "AudioSource",
           "Type": 8
         }
@@ -5907,7 +5907,7 @@
               ]
             },
             {
-              "AudioID": 13,
+              "AudioID": 30,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -6694,7 +6694,7 @@
               "UID": 1616070798
             },
             {
-              "AudioID": 14,
+              "AudioID": 31,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -6802,7 +6802,7 @@
           ]
         },
         {
-          "AudioID": 15,
+          "AudioID": 32,
           "Name": "AudioSource",
           "Type": 8
         }
@@ -6926,7 +6926,7 @@
           ]
         },
         {
-          "AudioID": 16,
+          "AudioID": 33,
           "Name": "AudioSource",
           "Type": 8
         }
@@ -6972,7 +6972,7 @@
           "UID": 2135104260
         },
         {
-          "AudioID": 21,
+          "AudioID": 34,
           "Name": "AudioSource",
           "Type": 8
         }
@@ -7018,7 +7018,7 @@
           "UID": 2581454987
         },
         {
-          "AudioID": 22,
+          "AudioID": 35,
           "Name": "AudioSource",
           "Type": 8
         }
@@ -7030,58 +7030,12 @@
       "ParentUID": 3452816845,
       "Static": false,
       "UID": 3452816845
-    },
-    {
-      "Components": [
-        {
-          "Name": "Transform",
-          "Transformation Matrix": [
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0
-          ],
-          "Type": 0,
-          "UID": 4072698855
-        },
-        {
-          "Name": "Script",
-          "ParentUID": 3452816845,
-          "ScriptName": "ItemManager",
-          "Type": 4,
-          "UID": 1110714302
-        },
-        {
-          "AudioID": 19,
-          "Name": "AudioSource",
-          "Type": 8
-        }
-      ],
-      "Enabled": true,
-      "HasTransparency": false,
-      "Keeped": false,
-      "Name": "Manager",
-      "ParentUID": 3452816845,
-      "Static": false,
-      "UID": 3452816845
     }
   ],
   "HasTransparency": false,
   "Keeped": false,
   "Name": "UI_Manager",
-  "ParentUID": 3452816845,
+  "ParentUID": 6619207,
   "PrefabDirty": false,
   "PrefabID": 2472160759,
   "PrefabName": "UI_Manager",

--- a/TheOneEditor/Assets/Scenes/ChestbursterTest.toe
+++ b/TheOneEditor/Assets/Scenes/ChestbursterTest.toe
@@ -39,13 +39,20 @@
           "Yaw": 0.0,
           "zFar": 3000.0,
           "zNear": 0.1
+        },
+        {
+          "Name": "Script",
+          "ParentUID": 3452816845,
+          "ScriptName": "CameraMovement",
+          "Type": 4,
+          "UID": 684541194
         }
       ],
       "Enabled": true,
       "HasTransparency": false,
       "Keeped": false,
       "Name": "mainCamera",
-      "ParentUID": 3452816845,
+      "ParentUID": 69993984,
       "Static": false,
       "UID": 3452816845
     },
@@ -119,105 +126,207 @@
       ],
       "EditablePrefab": true,
       "Enabled": true,
+      "GameObjects": [
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.1084357020372626,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 3974995229
+            },
+            {
+              "Emmiters": [
+                {
+                  "Delay": 0.5,
+                  "Duration": 1.0,
+                  "InitializeModules": [
+                    {
+                      "MaxDirection": [
+                        0.5,
+                        1.0,
+                        2.0
+                      ],
+                      "MinDirection": [
+                        -0.5,
+                        0.0,
+                        1.0
+                      ],
+                      "Type": 4,
+                      "UsingSingleValueDirection": false
+                    },
+                    {
+                      "MaxSpeed": 100.0,
+                      "MinSpeed": 80.0,
+                      "Type": 0,
+                      "UsingSingleValueSpeed": false
+                    }
+                  ],
+                  "IsLooping": false,
+                  "Lifetime": 0.0,
+                  "MaxParticles": 100,
+                  "RenderModule": [
+                    {
+                      "BillboardType": 1,
+                      "TexturePath": "",
+                      "Type": 0
+                    }
+                  ],
+                  "SpawnModule": [
+                    {
+                      "Amount": 20.0,
+                      "Duration": 0.30000001192092896,
+                      "Type": 1
+                    }
+                  ],
+                  "UpdateModules": [
+                    {
+                      "FinalScale": [
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "Type": 2
+                    }
+                  ]
+                }
+              ],
+              "Name": "TailPunchPS\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+              "StartON": false,
+              "Type": 9,
+              "UID": 3342647550
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "TailPunchPS",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 2188662575
+            },
+            {
+              "Emmiters": [
+                {
+                  "Delay": 0.5,
+                  "Duration": 1.0,
+                  "InitializeModules": [
+                    {
+                      "MaxDirection": [
+                        0.5,
+                        1.0,
+                        0.5
+                      ],
+                      "MinDirection": [
+                        -0.5,
+                        0.0,
+                        -0.5
+                      ],
+                      "Type": 4,
+                      "UsingSingleValueDirection": false
+                    },
+                    {
+                      "MaxSpeed": 100.0,
+                      "MinSpeed": 80.0,
+                      "Type": 0,
+                      "UsingSingleValueSpeed": false
+                    }
+                  ],
+                  "IsLooping": false,
+                  "Lifetime": 0.0,
+                  "MaxParticles": 100,
+                  "RenderModule": [
+                    {
+                      "BillboardType": 1,
+                      "TexturePath": "",
+                      "Type": 0
+                    }
+                  ],
+                  "SpawnModule": [
+                    {
+                      "Amount": 20.0,
+                      "Duration": 0.30000001192092896,
+                      "Type": 1
+                    }
+                  ],
+                  "UpdateModules": [
+                    {
+                      "FinalScale": [
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "Type": 2
+                    }
+                  ]
+                }
+              ],
+              "Name": "TailTripPS\u0000tem\u0000\u0000\u0000\u0000\u0000\u0000",
+              "StartON": false,
+              "Type": 9,
+              "UID": 1703738798
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "TailTripPS",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        }
+      ],
       "HasTransparency": false,
       "Keeped": false,
-      "Name": "Chestburster",
-      "ParentUID": 3452816845,
+      "Name": "Chestburster (1)",
+      "ParentUID": 69993984,
       "PrefabDirty": false,
       "PrefabID": 4037396494,
       "PrefabName": "Chestburster",
       "Static": false,
       "UID": 3452816845
-    },
-    {
-      "Components": [
-        {
-          "Name": "Transform",
-          "Transformation Matrix": [
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0
-          ],
-          "Type": 0,
-          "UID": 672686657
-        },
-        {
-          "Name": "Script",
-          "ParentUID": 6619240,
-          "ScriptName": "GameManager",
-          "Type": 4,
-          "UID": 467118552
-        }
-      ],
-      "EditablePrefab": true,
-      "Enabled": true,
-      "HasTransparency": false,
-      "Keeped": false,
-      "Name": "GameManager",
-      "ParentUID": 3452816845,
-      "PrefabDirty": false,
-      "PrefabID": 3294318030,
-      "PrefabName": "GameManager",
-      "Static": false,
-      "UID": 6619240
-    },
-    {
-      "Components": [
-        {
-          "Name": "Transform",
-          "Transformation Matrix": [
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0
-          ],
-          "Type": 0,
-          "UID": 4180287200
-        },
-        {
-          "Name": "Script",
-          "ParentUID": 6619240,
-          "ScriptName": "ItemManager",
-          "Type": 4,
-          "UID": 2738842466
-        }
-      ],
-      "EditablePrefab": true,
-      "Enabled": true,
-      "HasTransparency": false,
-      "Keeped": false,
-      "Name": "ItemManager",
-      "ParentUID": 3452816845,
-      "PrefabDirty": false,
-      "PrefabID": 1145673280,
-      "PrefabName": "ItemManager",
-      "Static": false,
-      "UID": 6619240
     },
     {
       "Components": [
@@ -242,7 +351,7 @@
             1.0
           ],
           "Type": 0,
-          "UID": 2164112949
+          "UID": 47571003
         },
         {
           "Active": true,
@@ -255,16 +364,16 @@
           "MaterialPath": "Library/Materials/AS_MainCharacter_TPose/M_MainCharacter.toematerial",
           "MeshPath": "Library/Meshes/AS_MainCharacter_TPose/SK_MainCharacter.animator",
           "Name": "Mesh",
-          "ParentUID": 3452816845,
+          "ParentUID": 113510800,
           "Type": 2,
-          "UID": 1372494642
+          "UID": 3098960481
         },
         {
           "Name": "Script",
-          "ParentUID": 3452816845,
+          "ParentUID": 113510800,
           "ScriptName": "PlayerScript",
           "Type": 4,
-          "UID": 4197445285
+          "UID": 225613267
         },
         {
           "AudioID": 1,
@@ -280,22 +389,7741 @@
           "ObjectOrientation": 0,
           "OffsetX": 0.0,
           "OffsetY": 0.0,
-          "ParentUID": 3452816845,
+          "ParentUID": 113510800,
           "Radius": 12.0,
           "Type": 5,
-          "UID": 1944253935,
+          "UID": 3282283334,
           "Width": -1.7976931348623157e+308
         }
       ],
       "EditablePrefab": true,
       "Enabled": true,
+      "GameObjects": [
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                -0.10000000149011612,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 1533776541
+            },
+            {
+              "Emmiters": [
+                {
+                  "Delay": 0.0,
+                  "Duration": 1.0,
+                  "InitializeModules": [
+                    {
+                      "MaxDirection": [
+                        1.0,
+                        1.0,
+                        -5.0
+                      ],
+                      "MinDirection": [
+                        -1.0,
+                        0.0,
+                        -0.5
+                      ],
+                      "Type": 4,
+                      "UsingSingleValueDirection": false
+                    },
+                    {
+                      "MaxSpeed": 15.0,
+                      "MinSpeed": 5.0,
+                      "Type": 0,
+                      "UsingSingleValueSpeed": false
+                    },
+                    {
+                      "MaxColor": [
+                        250.0,
+                        250.0,
+                        250.0,
+                        255.0
+                      ],
+                      "MinColor": [
+                        240.0,
+                        240.0,
+                        240.0,
+                        255.0
+                      ],
+                      "Type": 1,
+                      "UsingSingleValueColor": false
+                    }
+                  ],
+                  "IsLooping": true,
+                  "Lifetime": 745.2593994140625,
+                  "MaxParticles": 20,
+                  "RenderModule": [
+                    {
+                      "BillboardType": 0,
+                      "TexturePath": "",
+                      "Type": 0
+                    }
+                  ],
+                  "SpawnModule": [
+                    {
+                      "Amount": 10.0,
+                      "Duration": 0.800000011920929,
+                      "SpawnRate": 1.5499999523162842,
+                      "Type": 2
+                    }
+                  ],
+                  "UpdateModules": [
+                    {
+                      "Acceleration": [
+                        0.0,
+                        10.0,
+                        0.0
+                      ],
+                      "Type": 0
+                    },
+                    {
+                      "AffectA": true,
+                      "AffectB": false,
+                      "AffectG": false,
+                      "AffectR": false,
+                      "FinalColor": [
+                        255.0,
+                        255.0,
+                        255.0,
+                        0.0
+                      ],
+                      "Type": 1
+                    },
+                    {
+                      "FinalScale": [
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "Type": 2
+                    }
+                  ]
+                }
+              ],
+              "Name": "P_Run_Dust\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+              "StartON": false,
+              "Type": 9,
+              "UID": 402248169
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "StepsPS",
+          "ParentUID": 113510800,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.28999999165534973,
+                0.09000000357627869,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 2719197524
+            },
+            {
+              "Emmiters": [
+                {
+                  "Delay": 0.0,
+                  "Duration": 0.5,
+                  "InitializeModules": [
+                    {
+                      "MaxDirection": [
+                        6.0,
+                        10.0,
+                        120.0
+                      ],
+                      "MinDirection": [
+                        -6.0,
+                        -2.0,
+                        75.0
+                      ],
+                      "Type": 4,
+                      "UsingSingleValueDirection": false
+                    },
+                    {
+                      "MaxSpeed": 120.0,
+                      "MinSpeed": 75.0,
+                      "Type": 0,
+                      "UsingSingleValueSpeed": false
+                    },
+                    {
+                      "MaxColor": [
+                        255.0,
+                        255.0,
+                        0.0,
+                        255.0
+                      ],
+                      "MinColor": [
+                        210.0,
+                        128.0,
+                        0.0,
+                        255.0
+                      ],
+                      "Type": 1,
+                      "UsingSingleValueColor": false
+                    },
+                    {
+                      "IsProportional": true,
+                      "MaxScale": [
+                        1.0,
+                        1.0,
+                        0.0
+                      ],
+                      "MinScale": [
+                        0.2,
+                        0.1,
+                        0.0
+                      ],
+                      "Type": 2,
+                      "UsingSingleValueScale": false
+                    }
+                  ],
+                  "IsLooping": false,
+                  "Lifetime": 0.0,
+                  "MaxParticles": 50,
+                  "RenderModule": [
+                    {
+                      "BillboardType": 1,
+                      "TexturePath": "",
+                      "Type": 0
+                    }
+                  ],
+                  "SpawnModule": [
+                    {
+                      "Amount": 10.0,
+                      "Duration": 0.20000000298023224,
+                      "Type": 1
+                    }
+                  ],
+                  "UpdateModules": [
+                    {
+                      "Acceleration": [
+                        0.0,
+                        -20.0,
+                        0.0
+                      ],
+                      "Type": 0
+                    },
+                    {
+                      "FinalScale": [
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "Type": 2
+                    }
+                  ]
+                },
+                {
+                  "Delay": 0.0,
+                  "Duration": 0.5,
+                  "InitializeModules": [
+                    {
+                      "MaxDirection": [
+                        6.0,
+                        10.0,
+                        150.0
+                      ],
+                      "MinDirection": [
+                        -6.0,
+                        -2.0,
+                        100.0
+                      ],
+                      "Type": 4,
+                      "UsingSingleValueDirection": false
+                    },
+                    {
+                      "MaxSpeed": 150.0,
+                      "MinSpeed": 100.0,
+                      "Type": 0,
+                      "UsingSingleValueSpeed": false
+                    },
+                    {
+                      "MaxColor": [
+                        255.0,
+                        255.0,
+                        0.0,
+                        255.0
+                      ],
+                      "MinColor": [
+                        210.0,
+                        128.0,
+                        0.0,
+                        255.0
+                      ],
+                      "Type": 1,
+                      "UsingSingleValueColor": false
+                    },
+                    {
+                      "IsProportional": true,
+                      "MaxScale": [
+                        1.0,
+                        0.1,
+                        2.0
+                      ],
+                      "MinScale": [
+                        0.2,
+                        0.1,
+                        1.0
+                      ],
+                      "Type": 2,
+                      "UsingSingleValueScale": false
+                    }
+                  ],
+                  "IsLooping": false,
+                  "Lifetime": 0.0,
+                  "MaxParticles": 100,
+                  "RenderModule": [
+                    {
+                      "BillboardType": 0,
+                      "TexturePath": "",
+                      "Type": 0
+                    }
+                  ],
+                  "SpawnModule": [
+                    {
+                      "Amount": 10.0,
+                      "Duration": 0.20000000298023224,
+                      "Type": 1
+                    }
+                  ],
+                  "UpdateModules": [
+                    {
+                      "Acceleration": [
+                        0.0,
+                        -20.0,
+                        0.0
+                      ],
+                      "Type": 0
+                    }
+                  ]
+                }
+              ],
+              "Name": "P_ShootM4\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+              "StartON": false,
+              "Type": 9,
+              "UID": 4200920531
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "ShotPlayerPS",
+          "ParentUID": 113510800,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 3630276037
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "AbilityDash",
+              "Type": 4,
+              "UID": 3667515160
+            },
+            {
+              "AudioID": 2,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Dash Ability",
+          "ParentUID": 113510800,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 3610690573
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "AbilityAdrenalineRush",
+              "Type": 4,
+              "UID": 1177981766
+            },
+            {
+              "AudioID": 3,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Adrenaline Rush Ability",
+          "ParentUID": 113510800,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 714224593
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "AbilityFlamethrower",
+              "Type": 4,
+              "UID": 2174904043
+            },
+            {
+              "AudioID": 4,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Flamethrower Ability",
+          "ParentUID": 113510800,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 2980399194
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "AbilityGrenadeLauncher",
+              "Type": 4,
+              "UID": 2232833499
+            },
+            {
+              "AudioID": 5,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Grenade Launcher Ability",
+          "ParentUID": 113510800,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 788044230
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "AbilityHeal",
+              "Type": 4,
+              "UID": 2199890485
+            },
+            {
+              "AudioID": 6,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Heal Ability",
+          "ParentUID": 113510800,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 361457508
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "AbilityImpaciente",
+              "Type": 4,
+              "UID": 3061441302
+            },
+            {
+              "AudioID": 7,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Impaciente Ability",
+          "ParentUID": 113510800,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 2910740634
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "AbilityShield",
+              "Type": 4,
+              "UID": 1809667645
+            },
+            {
+              "AudioID": 8,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Shield Ability",
+          "ParentUID": 113510800,
+          "Static": false,
+          "UID": 3452816845
+        }
+      ],
       "HasTransparency": false,
       "Keeped": false,
       "Name": "SK_MainCharacter",
-      "ParentUID": 3452816845,
-      "PrefabDirty": false,
-      "PrefabID": 2959458870,
+      "ParentUID": 69993984,
+      "PrefabDirty": true,
+      "PrefabID": 186710944,
       "PrefabName": "SK_MainCharacter",
+      "Static": false,
+      "UID": 113510800
+    },
+    {
+      "Components": [
+        {
+          "Name": "Transform",
+          "Transformation Matrix": [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0
+          ],
+          "Type": 0,
+          "UID": 3560769835
+        },
+        {
+          "Name": "Script",
+          "ParentUID": 3452816845,
+          "ScriptName": "UiManager",
+          "Type": 4,
+          "UID": 2371490470
+        },
+        {
+          "AudioID": 9,
+          "Name": "AudioSource",
+          "Type": 8
+        }
+      ],
+      "EditablePrefab": true,
+      "Enabled": true,
+      "GameObjects": [
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 2889362756
+            },
+            {
+              "DebugDraw": true,
+              "Enabled": false,
+              "Name": "Canvas",
+              "ParentUID": 3452816845,
+              "Rect": [
+                0.0,
+                0.0,
+                2.0,
+                2.0
+              ],
+              "Type": 6,
+              "UID": 149174467,
+              "UiElements": [
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 3269413881,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_StatsTitle",
+                  "Print": true,
+                  "Rect": [
+                    -0.7599999904632568,
+                    -0.7400000095367432,
+                    0.03999999910593033,
+                    0.05999999865889549
+                  ],
+                  "State": 0,
+                  "TextString": "stats",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 31171813,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_UpgradeButton",
+                  "Print": true,
+                  "Rect": [
+                    -0.6949999928474426,
+                    -0.5849999785423279,
+                    0.03999999910593033,
+                    0.05999999865889549
+                  ],
+                  "State": 0,
+                  "TextString": "upgrade",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 3222192157,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_CurentLoadout",
+                  "Print": true,
+                  "Rect": [
+                    -0.7250000238418579,
+                    -0.27000001072883606,
+                    0.019999999552965164,
+                    0.03500000014901161
+                  ],
+                  "State": 0,
+                  "TextString": "shoulder\nlaser",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 1095913263,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_CurentConsumable",
+                  "Print": true,
+                  "Rect": [
+                    -0.6000000238418579,
+                    0.10499999672174454,
+                    0.03500000014901161,
+                    0.054999999701976776
+                  ],
+                  "State": 0,
+                  "TextString": "bandages",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    0.4300000071525574,
+                    1.0,
+                    0.4300000071525574,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2254963903,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_CurentConsumableCharges",
+                  "Print": true,
+                  "Rect": [
+                    -0.6000000238418579,
+                    0.23000000417232513,
+                    0.029999999329447746,
+                    0.05000000074505806
+                  ],
+                  "State": 0,
+                  "TextString": "2/3",
+                  "Type": 4
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 4224993993,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_UpgradeMenu",
+                  "Print": true,
+                  "Rect": [
+                    -0.5799999833106995,
+                    -0.6050000190734863,
+                    0.1850000023841858,
+                    0.0949999988079071
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 3644016856,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_CurrentLoadout",
+                  "Print": true,
+                  "Rect": [
+                    -0.5799999833106995,
+                    -0.22499999403953552,
+                    0.1850000023841858,
+                    0.125
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 4135507180,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_CurrentConsumable",
+                  "Print": true,
+                  "Rect": [
+                    -0.6899999976158142,
+                    0.15000000596046448,
+                    0.06499999761581421,
+                    0.125
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2992342578,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot1",
+                  "Print": true,
+                  "Rect": [
+                    -0.6700000166893005,
+                    0.4650000035762787,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 472437747,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot2",
+                  "Print": true,
+                  "Rect": [
+                    -0.4449999928474426,
+                    0.4650000035762787,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2712333165,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot3",
+                  "Print": true,
+                  "Rect": [
+                    -0.2199999988079071,
+                    0.4650000035762787,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2773404253,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot4",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.4650000035762787,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2284154807,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot5",
+                  "Print": true,
+                  "Rect": [
+                    0.2199999988079071,
+                    0.4650000035762787,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 102809899,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot6",
+                  "Print": true,
+                  "Rect": [
+                    0.4399999976158142,
+                    0.4650000035762787,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 4195015686,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot7",
+                  "Print": true,
+                  "Rect": [
+                    0.6600000262260437,
+                    0.4650000035762787,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 532101273,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot8",
+                  "Print": true,
+                  "Rect": [
+                    -0.6700000166893005,
+                    0.7300000190734863,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 3570391770,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot9",
+                  "Print": true,
+                  "Rect": [
+                    -0.4449999928474426,
+                    0.7300000190734863,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2593558636,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot10",
+                  "Print": true,
+                  "Rect": [
+                    -0.2199999988079071,
+                    0.7300000190734863,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2713866311,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot11",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.7300000190734863,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 3070744380,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot12",
+                  "Print": true,
+                  "Rect": [
+                    0.2199999988079071,
+                    0.7300000190734863,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2220696733,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot13",
+                  "Print": true,
+                  "Rect": [
+                    0.4399999976158142,
+                    0.7300000190734863,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 706097468,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26252806186676025,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionIdle": [
+                    0.009723260998725891,
+                    0.002051281975582242,
+                    0.22139117121696472,
+                    0.13641025125980377
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_InventorySlot14",
+                  "Print": true,
+                  "Rect": [
+                    0.6600000262260437,
+                    0.7300000190734863,
+                    0.10000000149011612,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "ID": 149134431,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.6095736622810364,
+                    0.25333333015441895,
+                    0.07479431480169296,
+                    0.10256410390138626
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_AbilityIconLeft",
+                  "Print": true,
+                  "Rect": [
+                    0.38999998569488525,
+                    -0.2199999988079071,
+                    0.05999999865889549,
+                    0.10499999672174454
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 3786996359,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.8511593341827393,
+                    0.25333333015441895,
+                    0.07479431480169296,
+                    0.10256410390138626
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_AbilityIconRight",
+                  "Print": true,
+                  "Rect": [
+                    0.6449999809265137,
+                    -0.2199999988079071,
+                    0.05999999865889549,
+                    0.10499999672174454
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 1178968805,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.7681376338005066,
+                    0.25333333015441895,
+                    0.07479431480169296,
+                    0.10256410390138626
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_AbilityIconTop",
+                  "Print": true,
+                  "Rect": [
+                    0.5199999809265137,
+                    -0.4350000023841858,
+                    0.05999999865889549,
+                    0.10499999672174454
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 1461606610,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.6873597502708435,
+                    0.25333333015441895,
+                    0.07479431480169296,
+                    0.10256410390138626
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_AbilityIconBot",
+                  "Print": true,
+                  "Rect": [
+                    0.5199999809265137,
+                    0.009999999776482582,
+                    0.05999999865889549,
+                    0.10499999672174454
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 3286584945,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.30815258622169495,
+                    0.3774358928203583,
+                    0.1421092003583908,
+                    0.19487179815769196
+                  ],
+                  "ImageSectionIdle": [
+                    0.30815258622169495,
+                    0.16410256922245026,
+                    0.1421092003583908,
+                    0.19487179815769196
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_AbilityLeft",
+                  "Print": true,
+                  "Rect": [
+                    0.3799999952316284,
+                    -0.2199999988079071,
+                    0.10499999672174454,
+                    0.18000000715255737
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 441395597,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.4540014863014221,
+                    0.3774358928203583,
+                    0.1421092003583908,
+                    0.19487179815769196
+                  ],
+                  "ImageSectionIdle": [
+                    0.4540014863014221,
+                    0.16410256922245026,
+                    0.1421092003583908,
+                    0.19487179815769196
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_AbilityRight",
+                  "Print": true,
+                  "Rect": [
+                    0.6549999713897705,
+                    -0.2150000035762787,
+                    0.10499999672174454,
+                    0.18000000715255737
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 4068446478,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.004487658850848675,
+                    0.3774358928203583,
+                    0.1421092003583908,
+                    0.19487179815769196
+                  ],
+                  "ImageSectionIdle": [
+                    0.004487658850848675,
+                    0.16410256922245026,
+                    0.1421092003583908,
+                    0.19487179815769196
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_AbilityTop",
+                  "Print": true,
+                  "Rect": [
+                    0.5099999904632568,
+                    -0.44999998807907104,
+                    0.10499999672174454,
+                    0.18000000715255737
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 48618157,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.14809274673461914,
+                    0.3774358928203583,
+                    0.1421092003583908,
+                    0.19487179815769196
+                  ],
+                  "ImageSectionIdle": [
+                    0.14809274673461914,
+                    0.16410256922245026,
+                    0.1421092003583908,
+                    0.19487179815769196
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_AbilityBot",
+                  "Print": true,
+                  "Rect": [
+                    0.5099999904632568,
+                    0.019999999552965164,
+                    0.10499999672174454,
+                    0.18000000715255737
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "ID": 3866724295,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.6073298454284668,
+                    0.4276922941207886,
+                    0.052356019616127014,
+                    0.07179487496614456
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_AbilityArrowLeft",
+                  "Print": true,
+                  "Rect": [
+                    0.5099999904632568,
+                    -0.2150000035762787,
+                    0.04500000178813934,
+                    0.07500000298023224
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 4064493552,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.6522064208984375,
+                    0.4276922941207886,
+                    0.052356019616127014,
+                    0.07179487496614456
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_AbilityArrowRight",
+                  "Print": true,
+                  "Rect": [
+                    0.5099999904632568,
+                    -0.2150000035762787,
+                    0.04500000178813934,
+                    0.07500000298023224
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 4191828681,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.7030665874481201,
+                    0.4276922941207886,
+                    0.052356019616127014,
+                    0.07179487496614456
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_AbilityArrowTop",
+                  "Print": true,
+                  "Rect": [
+                    0.5099999904632568,
+                    -0.2150000035762787,
+                    0.04500000178813934,
+                    0.07500000298023224
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 1404963501,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.7546746730804443,
+                    0.417435884475708,
+                    0.052356019616127014,
+                    0.07179487496614456
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_AbilityArrowBot",
+                  "Print": true,
+                  "Rect": [
+                    0.5099999904632568,
+                    -0.2150000035762787,
+                    0.04500000178813934,
+                    0.07500000298023224
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 3005355180,
+                  "ImagePath": "Assets\\Textures\\Hud\\MainCharPortrait_Inventory.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    1.0,
+                    1.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_CharacterImage",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    -0.23000000417232513,
+                    0.17000000178813934,
+                    0.5550000071525574
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 3735024186,
+                  "ImagePath": "Assets\\Textures\\Hud\\Inventory_Screen_Background.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    1.0,
+                    1.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_BackGround",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.0,
+                    0.8349999785423279,
+                    0.9300000071525574
+                  ],
+                  "State": 0,
+                  "Type": 0
+                }
+              ]
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "UiScriptInventory",
+              "Type": 4,
+              "UID": 951121546
+            },
+            {
+              "AudioID": 10,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": false,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Canvas_Inventory",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 595373127
+            },
+            {
+              "DebugDraw": false,
+              "Enabled": false,
+              "Name": "Canvas",
+              "ParentUID": 3452816845,
+              "Rect": [
+                0.0,
+                0.0,
+                2.0,
+                2.0
+              ],
+              "Type": 6,
+              "UID": 594365140,
+              "UiElements": [
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2658540040,
+                  "ImagePath": "Assets/Textures/Hud/PauseMenu_SpriteSheetV2.png",
+                  "ImageSectionHovered": [
+                    0.0,
+                    0.4722598195075989,
+                    0.24569639563560486,
+                    0.46143436431884766
+                  ],
+                  "ImageSectionIdle": [
+                    0.0,
+                    0.0,
+                    0.24569639563560486,
+                    0.46143436431884766
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_Inventory",
+                  "Print": true,
+                  "Rect": [
+                    -0.3499999940395355,
+                    -0.33000001311302185,
+                    0.33500000834465027,
+                    0.2800000011920929
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 1751157100,
+                  "ImagePath": "Assets/Textures/Hud/PauseMenu_SpriteSheetV2.png",
+                  "ImageSectionHovered": [
+                    0.24687011539936066,
+                    0.4722598195075989,
+                    0.24569639563560486,
+                    0.46143436431884766
+                  ],
+                  "ImageSectionIdle": [
+                    0.24687011539936066,
+                    0.0,
+                    0.24569639563560486,
+                    0.46143436431884766
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_Missions",
+                  "Print": true,
+                  "Rect": [
+                    0.33000001311302185,
+                    -0.33000001311302185,
+                    0.33500000834465027,
+                    0.2800000011920929
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2075171387,
+                  "ImagePath": "Assets/Textures/Hud/PauseMenu_SpriteSheetV2.png",
+                  "ImageSectionHovered": [
+                    0.5058685541152954,
+                    0.00405954010784626,
+                    0.24256651103496552,
+                    0.22598105669021606
+                  ],
+                  "ImageSectionIdle": [
+                    0.7566510438919067,
+                    0.00405954010784626,
+                    0.24256651103496552,
+                    0.22868742048740387
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_Resume",
+                  "Print": true,
+                  "Rect": [
+                    -0.36000001430511475,
+                    0.15000000596046448,
+                    0.3400000035762787,
+                    0.15000000596046448
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 3024552604,
+                  "ImagePath": "Assets/Textures/Hud/PauseMenu_SpriteSheetV2.png",
+                  "ImageSectionHovered": [
+                    0.5058685541152954,
+                    0.25033828616142273,
+                    0.24256651103496552,
+                    0.22598105669021606
+                  ],
+                  "ImageSectionIdle": [
+                    0.7566510438919067,
+                    0.25033828616142273,
+                    0.24256651103496552,
+                    0.22868742048740387
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_Settings",
+                  "Print": true,
+                  "Rect": [
+                    0.3400000035762787,
+                    0.15000000596046448,
+                    0.3400000035762787,
+                    0.15000000596046448
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2405774430,
+                  "ImagePath": "Assets/Textures/Hud/PauseMenu_SpriteSheetV2.png",
+                  "ImageSectionHovered": [
+                    0.5058685541152954,
+                    0.49661704897880554,
+                    0.24256651103496552,
+                    0.22868742048740387
+                  ],
+                  "ImageSectionIdle": [
+                    0.7566510438919067,
+                    0.5047361254692078,
+                    0.24256651103496552,
+                    0.22868742048740387
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_Menu",
+                  "Print": true,
+                  "Rect": [
+                    -0.36000001430511475,
+                    0.5099999904632568,
+                    0.3400000035762787,
+                    0.15000000596046448
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 3811829014,
+                  "ImagePath": "Assets/Textures/Hud/PauseMenu_SpriteSheetV2.png",
+                  "ImageSectionHovered": [
+                    0.5058685541152954,
+                    0.7550744414329529,
+                    0.24256651103496552,
+                    0.22868742048740387
+                  ],
+                  "ImageSectionIdle": [
+                    0.7566510438919067,
+                    0.7618403434753418,
+                    0.24256651103496552,
+                    0.22868742048740387
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_Save&Quit",
+                  "Print": true,
+                  "Rect": [
+                    0.3400000035762787,
+                    0.5099999904632568,
+                    0.3400000035762787,
+                    0.15000000596046448
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "ID": 2448393211,
+                  "ImagePath": "Assets/Textures/Hud/PauseMenu_SpriteSheetV2.png",
+                  "ImageSection": [
+                    0.0,
+                    0.97428959608078,
+                    0.49687010049819946,
+                    0.02841677889227867
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Slide",
+                  "Print": true,
+                  "Rect": [
+                    -0.009999999776482582,
+                    -0.03999999910593033,
+                    0.6899999976158142,
+                    0.019999999552965164
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 1973608398,
+                  "ImagePath": "Assets/Textures/Hud/PauseMenu_BG.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    1.0,
+                    1.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Background",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.0,
+                    0.75,
+                    0.800000011920929
+                  ],
+                  "State": 0,
+                  "Type": 0
+                }
+              ]
+            },
+            {
+              "AudioID": 11,
+              "Name": "Source",
+              "Type": 8
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "UiScriptPause",
+              "Type": 4,
+              "UID": 1275044213
+            }
+          ],
+          "Enabled": false,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Canvas_PauseMenu",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 75598670
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "UiScriptHud",
+              "Type": 4,
+              "UID": 3891581621
+            },
+            {
+              "DebugDraw": true,
+              "Enabled": true,
+              "Name": "Canvas",
+              "ParentUID": 3452816845,
+              "Rect": [
+                0.0,
+                0.0,
+                2.0,
+                2.0
+              ],
+              "Type": 6,
+              "UID": 948763056,
+              "UiElements": [
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 665219275,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_MissionName",
+                  "Print": true,
+                  "Rect": [
+                    0.6200000047683716,
+                    -0.8700000047683716,
+                    0.029999999329447746,
+                    0.054999999701976776
+                  ],
+                  "State": 0,
+                  "TextString": "escape the ship",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 3804665374,
+                  "Interactuable": false,
+                  "Kerning": -0.09000000357627869,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_MissionDescription",
+                  "Print": true,
+                  "Rect": [
+                    0.6899999976158142,
+                    -0.7649999856948853,
+                    0.019999999552965164,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "find a gun",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2881826622,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_CurrencyAmount",
+                  "Print": true,
+                  "Rect": [
+                    -0.0949999988079071,
+                    -0.9150000214576721,
+                    0.029999999329447746,
+                    0.054999999701976776
+                  ],
+                  "State": 0,
+                  "TextString": "200",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 201470886,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_KillsAmount",
+                  "Print": true,
+                  "Rect": [
+                    0.10999999940395355,
+                    -0.9150000214576721,
+                    0.029999999329447746,
+                    0.054999999701976776
+                  ],
+                  "State": 0,
+                  "TextString": "0",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 1808470824,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_AmmoAmount",
+                  "Print": true,
+                  "Rect": [
+                    0.5600000023841858,
+                    0.824999988079071,
+                    0.03500000014901161,
+                    0.07500000298023224
+                  ],
+                  "State": 0,
+                  "TextString": "20 / 20",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 3506077180,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_CurrentLoadoutName",
+                  "Print": true,
+                  "Rect": [
+                    0.6949999928474426,
+                    0.9300000071525574,
+                    0.02500000037252903,
+                    0.03500000014901161
+                  ],
+                  "State": 0,
+                  "TextString": "m41a",
+                  "Type": 4
+                },
+                {
+                  "ID": 3176509821,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSection": [
+                    0.5063938498497009,
+                    0.1190476194024086,
+                    0.05797101557254791,
+                    0.0827067643404007
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_KillsIcon",
+                  "Print": true,
+                  "Rect": [
+                    0.07000000029802322,
+                    -0.9300000071525574,
+                    0.03700000047683716,
+                    0.05000000074505806
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 842829015,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSection": [
+                    0.35720375180244446,
+                    0.1190476194024086,
+                    0.05797101557254791,
+                    0.0827067643404007
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_CoinIcon",
+                  "Print": true,
+                  "Rect": [
+                    -0.14000000059604645,
+                    -0.9300000071525574,
+                    0.03700000047683716,
+                    0.05000000074505806
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 35655607,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSection": [
+                    0.27450981736183167,
+                    0.0,
+                    0.3682864308357239,
+                    0.11027568578720093
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_TopBar",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    -0.9300000071525574,
+                    0.25,
+                    0.07000000029802322
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 2674015246,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSection": [
+                    0.8653026223182678,
+                    0.5689222812652588,
+                    0.08525149524211884,
+                    0.12531328201293945
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_UsingWeaponIcon",
+                  "Print": true,
+                  "Rect": [
+                    0.8550000190734863,
+                    0.7850000262260437,
+                    0.06499999761581421,
+                    0.0949999988079071
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 712819043,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSection": [
+                    0.3606138229370117,
+                    0.5989974737167358,
+                    0.3375959098339081,
+                    0.15664160251617432
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_WeaponBar",
+                  "Print": true,
+                  "Rect": [
+                    0.7350000143051147,
+                    0.8450000286102295,
+                    0.25,
+                    0.11999999731779099
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 1379403983,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSection": [
+                    0.5814151763916016,
+                    0.26817041635513306,
+                    0.1304347813129425,
+                    0.21177944540977478
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Character",
+                  "Print": true,
+                  "Rect": [
+                    -0.8299999833106995,
+                    -0.7799999713897705,
+                    0.10000000149011612,
+                    0.15000000596046448
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 538784177,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSection": [
+                    0.007672634441405535,
+                    0.0,
+                    0.25745949149131775,
+                    0.07769423723220825
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_LifeBar",
+                  "Print": true,
+                  "Rect": [
+                    -0.6100000143051147,
+                    -0.6499999761581421,
+                    0.15000000596046448,
+                    0.05000000074505806
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 1568388406,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSection": [
+                    0.06564364582300186,
+                    0.08897243440151215,
+                    0.03324808180332184,
+                    0.05388471111655235
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_LifeIcon",
+                  "Print": true,
+                  "Rect": [
+                    -0.4399999976158142,
+                    -0.6399999856948853,
+                    0.02500000037252903,
+                    0.03400000184774399
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 470330285,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSection": [
+                    0.11679454147815704,
+                    0.09273182600736618,
+                    0.03324808180332184,
+                    0.04385964944958687
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_ShieldIcon",
+                  "Print": true,
+                  "Rect": [
+                    -0.4300000071525574,
+                    -0.7200000286102295,
+                    0.019999999552965164,
+                    0.02500000037252903
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 2584368681,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSection": [
+                    0.695652186870575,
+                    0.0,
+                    0.303495317697525,
+                    0.10025062412023544
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_MissionTitleBar",
+                  "Print": true,
+                  "Rect": [
+                    0.7699999809265137,
+                    -0.8899999856948853,
+                    0.20000000298023224,
+                    0.07999999821186066
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 3441965934,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSection": [
+                    0.8320545554161072,
+                    0.11403508484363556,
+                    0.15260016918182373,
+                    0.04385964944958687
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_MissionDescripionBar",
+                  "Print": true,
+                  "Rect": [
+                    0.800000011920929,
+                    -0.7799999713897705,
+                    0.15000000596046448,
+                    0.05000000074505806
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 2960779948,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.5933504104614258,
+                    0.7969924807548523,
+                    0.04433077573776245,
+                    0.06516290456056595
+                  ],
+                  "ImageSectionIdle": [
+                    0.5933504104614258,
+                    0.8771929740905762,
+                    0.04433077573776245,
+                    0.06516290456056595
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_ConsumibleIcon",
+                  "Print": true,
+                  "Rect": [
+                    -0.8299999833106995,
+                    -0.5600000023841858,
+                    0.03500000014901161,
+                    0.04500000178813934
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 2074112365,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.18414321541786194,
+                    0.2268170416355133,
+                    0.17902813851833344,
+                    0.3345864713191986
+                  ],
+                  "ImageSectionIdle": [
+                    0.0,
+                    0.2268170416355133,
+                    0.17902813851833344,
+                    0.3345864713191986
+                  ],
+                  "ImageSectionSelected": [
+                    0.3691389560699463,
+                    0.2268170416355133,
+                    0.17902813851833344,
+                    0.3345864713191986
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_ConsumibleLayout",
+                  "Print": true,
+                  "Rect": [
+                    -0.8299999833106995,
+                    -0.7300000190734863,
+                    0.14399999380111694,
+                    0.25
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 2086596910,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.6530264019966125,
+                    0.7969924807548523,
+                    0.04433077573776245,
+                    0.06516290456056595
+                  ],
+                  "ImageSectionIdle": [
+                    0.6530264019966125,
+                    0.8771929740905762,
+                    0.04433077573776245,
+                    0.06516290456056595
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_WeaponIcon1",
+                  "Print": true,
+                  "Rect": [
+                    -0.8650000095367432,
+                    -0.20999999344348907,
+                    0.03500000014901161,
+                    0.04500000178813934
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 3544150121,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.11338448524475098,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "ImageSectionIdle": [
+                    0.006820119451731443,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "ImageSectionSelected": [
+                    0.21994884312152863,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_WeaponSlot1",
+                  "Print": true,
+                  "Rect": [
+                    -0.8600000143051147,
+                    -0.20999999344348907,
+                    0.07000000029802322,
+                    0.10000000149011612
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 3286532927,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.7118499279022217,
+                    0.7969924807548523,
+                    0.04433077573776245,
+                    0.06516290456056595
+                  ],
+                  "ImageSectionIdle": [
+                    0.7118499279022217,
+                    0.8771929740905762,
+                    0.04433077573776245,
+                    0.06516290456056595
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_WeaponIcon2",
+                  "Print": true,
+                  "Rect": [
+                    -0.8650000095367432,
+                    -0.019999999552965164,
+                    0.03500000014901161,
+                    0.04500000178813934
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 812891308,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.11338448524475098,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "ImageSectionIdle": [
+                    0.006820119451731443,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "ImageSectionSelected": [
+                    0.21994884312152863,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_WeaponSlot2",
+                  "Print": true,
+                  "Rect": [
+                    -0.8600000143051147,
+                    -0.019999999552965164,
+                    0.07000000029802322,
+                    0.10000000149011612
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 4200218886,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.7791986465454102,
+                    0.7969924807548523,
+                    0.05456095561385155,
+                    0.06516290456056595
+                  ],
+                  "ImageSectionIdle": [
+                    0.7791986465454102,
+                    0.8771929740905762,
+                    0.05456095561385155,
+                    0.06516290456056595
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_WeaponIcon3",
+                  "Print": true,
+                  "Rect": [
+                    -0.8650000095367432,
+                    0.18000000715255737,
+                    0.03999999910593033,
+                    0.04500000178813934
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 858232316,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.11338448524475098,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "ImageSectionIdle": [
+                    0.006820119451731443,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "ImageSectionSelected": [
+                    0.21994884312152863,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_WeaponSlot3",
+                  "Print": true,
+                  "Rect": [
+                    -0.8600000143051147,
+                    0.17000000178813934,
+                    0.07000000029802322,
+                    0.10000000149011612
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 719882176,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.8559249639511108,
+                    0.7969924807548523,
+                    0.06479113548994064,
+                    0.06516290456056595
+                  ],
+                  "ImageSectionIdle": [
+                    0.8559249639511108,
+                    0.8771929740905762,
+                    0.06479113548994064,
+                    0.06516290456056595
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_WeaponIcon4",
+                  "Print": true,
+                  "Rect": [
+                    -0.8650000095367432,
+                    0.36000001430511475,
+                    0.04500000178813934,
+                    0.04500000178813934
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 62019211,
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.11338448524475098,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "ImageSectionIdle": [
+                    0.006820119451731443,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "ImageSectionSelected": [
+                    0.21994884312152863,
+                    0.6127819418907166,
+                    0.10059676319360733,
+                    0.13533835113048553
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_WeaponSlot4",
+                  "Print": true,
+                  "Rect": [
+                    -0.8600000143051147,
+                    0.36000001430511475,
+                    0.07000000029802322,
+                    0.10000000149011612
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "AdditionalOffsetFirst": 0.0,
+                  "AdditionalOffsetLast": 0.0,
+                  "ID": 1812522691,
+                  "ImageFirstSectionHovered": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionHoveredOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionIdle": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionIdleOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionHovered": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionHoveredOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionIdle": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionIdleOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionHoveredOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionIdle": [
+                    0.013640238903462887,
+                    0.08646616339683533,
+                    0.034100595861673355,
+                    0.05388471111655235
+                  ],
+                  "ImageSectionIdleOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "MaxValue": 10,
+                  "MinValue": 0,
+                  "Name": "Slider_HP",
+                  "Offset": -0.009999999776482582,
+                  "Print": true,
+                  "Rect": [
+                    -0.6970000267028809,
+                    -0.6449999809265137,
+                    0.019999999552965164,
+                    0.03999999910593033
+                  ],
+                  "SliderDesign": 0,
+                  "State": 0,
+                  "Type": 2,
+                  "Value": 10
+                },
+                {
+                  "AdditionalOffsetFirst": 0.03200000151991844,
+                  "AdditionalOffsetLast": 0.03400000184774399,
+                  "ID": 1464574036,
+                  "ImageFirstSectionHovered": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionHoveredOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionIdle": [
+                    0.7740835547447205,
+                    0.5338345766067505,
+                    0.052855923771858215,
+                    0.033834587782621384
+                  ],
+                  "ImageFirstSectionIdleOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionHovered": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionHoveredOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionIdle": [
+                    0.9309462904930115,
+                    0.5338345766067505,
+                    0.052855923771858215,
+                    0.033834587782621384
+                  ],
+                  "ImageLastSectionIdleOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionHoveredOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionIdle": [
+                    0.8277919888496399,
+                    0.5338345766067505,
+                    0.05115089565515518,
+                    0.033834587782621384
+                  ],
+                  "ImageSectionIdleOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "MaxValue": 4,
+                  "MinValue": 0,
+                  "Name": "Slider_Shield",
+                  "Offset": 0.009999999776482582,
+                  "Print": true,
+                  "Rect": [
+                    -0.6800000071525574,
+                    -0.7250000238418579,
+                    0.029999999329447746,
+                    0.02500000037252903
+                  ],
+                  "SliderDesign": 1,
+                  "State": 0,
+                  "Type": 2,
+                  "Value": 4
+                },
+                {
+                  "AdditionalOffsetFirst": 0.0,
+                  "AdditionalOffsetLast": 0.0,
+                  "ID": 388535485,
+                  "ImageFirstSectionHovered": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionHoveredOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionIdle": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionIdleOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageFirstSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionHovered": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionHoveredOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionIdle": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionIdleOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageLastSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImagePath": "Assets/Textures/Hud/HUD_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionHoveredOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionIdle": [
+                    0.7058823704719543,
+                    0.602756917476654,
+                    0.03069053776562214,
+                    0.04511278122663498
+                  ],
+                  "ImageSectionIdleOff": [
+                    0.7340153455734253,
+                    0.602756917476654,
+                    0.03069053776562214,
+                    0.04511278122663498
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "MaxValue": 10,
+                  "MinValue": 0,
+                  "Name": "Slider_Ammo",
+                  "Offset": -0.012000000104308128,
+                  "Print": true,
+                  "Rect": [
+                    0.49000000953674316,
+                    0.9150000214576721,
+                    0.019999999552965164,
+                    0.029999999329447746
+                  ],
+                  "SliderDesign": 0,
+                  "State": 0,
+                  "Type": 2,
+                  "Value": 10
+                }
+              ]
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Canvas_Hud",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 2450476722
+            },
+            {
+              "DebugDraw": false,
+              "Enabled": false,
+              "Name": "Canvas",
+              "ParentUID": 3452816845,
+              "Rect": [
+                0.0,
+                0.0,
+                2.0,
+                2.0
+              ],
+              "Type": 6,
+              "UID": 703908814,
+              "UiElements": [
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2893125401,
+                  "ImagePath": "Assets/Textures/Hud/DeathScreen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.746671736240387,
+                    0.1111111119389534,
+                    0.22251807153224945,
+                    0.03703703731298447
+                  ],
+                  "ImageSectionIdle": [
+                    0.746671736240387,
+                    0.1111111119389534,
+                    0.22251807153224945,
+                    0.03703703731298447
+                  ],
+                  "ImageSectionSelected": [
+                    0.746671736240387,
+                    0.14814814925193787,
+                    0.22251807153224945,
+                    0.03703703731298447
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_PressToContinue",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.6399999856948853,
+                    0.3499999940395355,
+                    0.03500000014901161
+                  ],
+                  "State": 2,
+                  "Type": 1
+                },
+                {
+                  "ID": 3684267540,
+                  "ImagePath": "Assets/Textures/Hud/DeathScreen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    0.7318372130393982,
+                    1.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Background",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.0,
+                    1.0,
+                    1.0
+                  ],
+                  "State": 0,
+                  "Type": 0
+                }
+              ]
+            }
+          ],
+          "Enabled": false,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Canvas_Death",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 4226595400
+            },
+            {
+              "DebugDraw": true,
+              "Enabled": false,
+              "Name": "Canvas",
+              "ParentUID": 3452816845,
+              "Rect": [
+                0.0,
+                0.0,
+                2.0,
+                2.0
+              ],
+              "Type": 6,
+              "UID": 3703257962,
+              "UiElements": [
+                {
+                  "CheckerActive": false,
+                  "ID": 3627327478,
+                  "ImagePath": "Assets/Textures/Hud/Debug_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.8817610144615173,
+                    0.31518152356147766,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionHoveredOff": [
+                    0.8817610144615173,
+                    0.4785478413105011,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionIdle": [
+                    0.8817610144615173,
+                    0.0,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionIdleOff": [
+                    0.8817610144615173,
+                    0.15841583907604218,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Checker_ColliderRender",
+                  "Print": true,
+                  "Rect": [
+                    -0.2549999952316284,
+                    -0.054999999701976776,
+                    0.04500000178813934,
+                    0.07999999821186066
+                  ],
+                  "State": 1,
+                  "Type": 3
+                },
+                {
+                  "CheckerActive": false,
+                  "ID": 4216972479,
+                  "ImagePath": "Assets/Textures/Hud/Debug_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.8817610144615173,
+                    0.31518152356147766,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionHoveredOff": [
+                    0.8817610144615173,
+                    0.4785478413105011,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionIdle": [
+                    0.8817610144615173,
+                    0.0,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionIdleOff": [
+                    0.8817610144615173,
+                    0.15841583907604218,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Checker_GridRender",
+                  "Print": true,
+                  "Rect": [
+                    0.12999999523162842,
+                    -0.054999999701976776,
+                    0.04500000178813934,
+                    0.07999999821186066
+                  ],
+                  "State": 0,
+                  "Type": 3
+                },
+                {
+                  "CheckerActive": false,
+                  "ID": 1918822137,
+                  "ImagePath": "Assets/Textures/Hud/Debug_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.8817610144615173,
+                    0.31518152356147766,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionHoveredOff": [
+                    0.8817610144615173,
+                    0.4785478413105011,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionIdle": [
+                    0.8817610144615173,
+                    0.0,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionIdleOff": [
+                    0.8817610144615173,
+                    0.15841583907604218,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Checker_GodMode",
+                  "Print": true,
+                  "Rect": [
+                    -0.2549999952316284,
+                    0.28999999165534973,
+                    0.04500000178813934,
+                    0.07999999821186066
+                  ],
+                  "State": 0,
+                  "Type": 3
+                },
+                {
+                  "CheckerActive": false,
+                  "ID": 2396922034,
+                  "ImagePath": "Assets/Textures/Hud/Debug_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.8817610144615173,
+                    0.31518152356147766,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionHoveredOff": [
+                    0.8817610144615173,
+                    0.4785478413105011,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionIdle": [
+                    0.8817610144615173,
+                    0.0,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionIdleOff": [
+                    0.8817610144615173,
+                    0.15841583907604218,
+                    0.11320754885673523,
+                    0.14851485192775726
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Checker_ExtraSpeed",
+                  "Print": true,
+                  "Rect": [
+                    0.12999999523162842,
+                    0.28999999165534973,
+                    0.04500000178813934,
+                    0.07999999821186066
+                  ],
+                  "State": 0,
+                  "Type": 3
+                },
+                {
+                  "ID": 1452984914,
+                  "ImagePath": "Assets/Textures/Hud/Debug_SpriteSheet.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    0.8743434548377991,
+                    1.0018283128738403
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Background",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.07500000298023224,
+                    0.4300000071525574,
+                    0.6100000143051147
+                  ],
+                  "State": 0,
+                  "Type": 0
+                }
+              ]
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "UiScriptDebug",
+              "Type": 4,
+              "UID": 607510851
+            },
+            {
+              "AudioID": 12,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": false,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Canvas_Debug",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 3102803846
+            },
+            {
+              "DebugDraw": true,
+              "Enabled": false,
+              "Name": "Canvas",
+              "ParentUID": 3452816845,
+              "Rect": [
+                0.0,
+                0.0,
+                2.0,
+                2.0
+              ],
+              "Type": 6,
+              "UID": 3123442631,
+              "UiElements": [
+                {
+                  "ID": 2441017390,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.22819314897060394,
+                    0.09494324028491974,
+                    0.3940809965133667,
+                    0.03818369284272194
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_MissionsInfo",
+                  "Print": true,
+                  "Rect": [
+                    0.3050000071525574,
+                    -0.5899999737739563,
+                    0.2750000059604645,
+                    0.04500000178813934
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 1309944859,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.37227413058280945,
+                    0.6057791709899902,
+                    0.050623051822185516,
+                    0.0784313753247261
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_MissionsInfoArrow",
+                  "Print": true,
+                  "Rect": [
+                    -0.03500000014901161,
+                    0.10499999672174454,
+                    0.05000000074505806,
+                    0.0949999988079071
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 607823039,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.0,
+                    0.26006191968917847,
+                    0.4236760139465332,
+                    0.11042311787605286
+                  ],
+                  "ImageSectionIdle": [
+                    0.0,
+                    0.14757481217384338,
+                    0.4236752390861511,
+                    0.11042311787605286
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_ToDo_Done",
+                  "Print": true,
+                  "Rect": [
+                    -0.35499998927116394,
+                    -0.5799999833106995,
+                    0.27000001072883606,
+                    0.07999999821186066
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 171599070,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.5887850522994995,
+                    0.20433436334133148,
+                    0.33255451917648315,
+                    0.055727552622556686
+                  ],
+                  "ImageSectionIdle": [
+                    0.5887850522994995,
+                    0.2837977409362793,
+                    0.33255451917648315,
+                    0.055727552622556686
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_MissionTypeRightPanel",
+                  "Print": true,
+                  "Rect": [
+                    0.30000001192092896,
+                    -0.38499999046325684,
+                    0.23499999940395355,
+                    0.04500000178813934
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "ID": 2478741276,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.59112149477005,
+                    0.4097007215023041,
+                    0.3956386148929596,
+                    0.07739938050508499
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Details",
+                  "Print": true,
+                  "Rect": [
+                    0.3199999928474426,
+                    -0.14000000059604645,
+                    0.24500000476837158,
+                    0.07000000029802322
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 3886539528,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.59112149477005,
+                    0.5655314922332764,
+                    0.3956386148929596,
+                    0.07739938050508499
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Objectives",
+                  "Print": true,
+                  "Rect": [
+                    0.3199999928474426,
+                    0.20999999344348907,
+                    0.24500000476837158,
+                    0.07000000029802322
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 2108229754,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.59112149477005,
+                    0.7471620440483093,
+                    0.3956386148929596,
+                    0.07739938050508499
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_MissionStatus",
+                  "Print": true,
+                  "Rect": [
+                    0.3199999928474426,
+                    0.5149999856948853,
+                    0.24500000476837158,
+                    0.07000000029802322
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 932965676,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.0,
+                    0.6274510025978088,
+                    0.13862928748130798,
+                    0.028895769268274307
+                  ],
+                  "ImageSectionIdle": [
+                    0.0,
+                    0.6656346917152405,
+                    0.13862928748130798,
+                    0.028895769268274307
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_MissionStatus",
+                  "Print": true,
+                  "Rect": [
+                    0.17499999701976776,
+                    0.6150000095367432,
+                    0.10499999672174454,
+                    0.029999999329447746
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 3339058309,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.007788162212818861,
+                    0.017543859779834747,
+                    0.07788161933422089,
+                    0.04540763795375824
+                  ],
+                  "ImageSectionIdle": [
+                    0.1059190034866333,
+                    0.017543859779834747,
+                    0.07788161933422089,
+                    0.04540763795375824
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_MissionTypeLeftPanel",
+                  "Print": true,
+                  "Rect": [
+                    -0.550000011920929,
+                    -0.3400000035762787,
+                    0.05999999865889549,
+                    0.04500000178813934
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CheckerActive": true,
+                  "ID": 3017230494,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.4322429895401001,
+                    0.8720329999923706,
+                    0.08644859492778778,
+                    0.11558307707309723
+                  ],
+                  "ImageSectionHoveredOff": [
+                    0.4322429895401001,
+                    0.5820433497428894,
+                    0.08644859492778778,
+                    0.11558307707309723
+                  ],
+                  "ImageSectionIdle": [
+                    0.4322429895401001,
+                    0.7254902124404907,
+                    0.08644859492778778,
+                    0.11558307707309723
+                  ],
+                  "ImageSectionIdleOff": [
+                    0.4322429895401001,
+                    0.43550050258636475,
+                    0.08644859492778778,
+                    0.11558307707309723
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "ImageSectionSelectedOff": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Checker_MissionActive",
+                  "Print": true,
+                  "Rect": [
+                    -0.14499999582767487,
+                    -0.3400000035762787,
+                    0.03999999910593033,
+                    0.07500000298023224
+                  ],
+                  "State": 0,
+                  "Type": 3
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    0.9399999976158142,
+                    1.0
+                  ],
+                  "FontPath": "Assets\\Fonts\\AlienInvader.ttf",
+                  "ID": 1702456573,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_MissionTitleRightPanel",
+                  "Print": true,
+                  "Rect": [
+                    -0.48500001430511475,
+                    -0.32499998807907104,
+                    0.02500000037252903,
+                    0.054999999701976776
+                  ],
+                  "State": 0,
+                  "TextString": "escape the ship",
+                  "Type": 4
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 3468629696,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.0,
+                    0.8586171269416809,
+                    0.4236760139465332,
+                    0.1413828730583191
+                  ],
+                  "ImageSectionIdle": [
+                    0.0,
+                    0.7089783549308777,
+                    0.4236760139465332,
+                    0.1413828730583191
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_MissionLayer",
+                  "Print": true,
+                  "Rect": [
+                    -0.35499998927116394,
+                    -0.3400000035762787,
+                    0.27000001072883606,
+                    0.12999999523162842
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "Color": [
+                    1.0,
+                    0.75,
+                    0.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets\\Fonts\\AlienInvader.ttf",
+                  "ID": 3895433980,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_MissionTitleRightPanel",
+                  "Print": true,
+                  "Rect": [
+                    0.07999999821186066,
+                    -0.2150000035762787,
+                    0.03999999910593033,
+                    0.08500000089406967
+                  ],
+                  "State": 0,
+                  "TextString": "escape the ship",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    0.8999999761581421,
+                    0.8999999761581421,
+                    0.8999999761581421,
+                    1.0
+                  ],
+                  "FontPath": "Assets\\Fonts\\AlienInvader.ttf",
+                  "ID": 3855266108,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_MissionDetailsRightPanel",
+                  "Print": true,
+                  "Rect": [
+                    0.07999999821186066,
+                    -0.004999999888241291,
+                    0.014999999664723873,
+                    0.029999999329447746
+                  ],
+                  "State": 0,
+                  "TextString": "you've managed to escape your cell, but the\nspaceship has been overrun by xenomorphs,\nlook for a weapon in this rubble of the\ncrashing and make your way out of the ship",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    0.8999999761581421,
+                    0.8999999761581421,
+                    0.8999999761581421,
+                    1.0
+                  ],
+                  "FontPath": "Assets\\Fonts\\AlienInvader.ttf",
+                  "ID": 2046570873,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 1.0,
+                  "Name": "Text_MissionObjectiveRightPanel",
+                  "Print": true,
+                  "Rect": [
+                    0.07999999821186066,
+                    0.3199999928474426,
+                    0.014999999664723873,
+                    0.029999999329447746
+                  ],
+                  "State": 0,
+                  "TextString": "Find a weapon\nMeke your way out of the ship",
+                  "Type": 4
+                },
+                {
+                  "ID": 2409450994,
+                  "ImagePath": "Assets/Textures/Hud/Missions_Screen_Background.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    1.0,
+                    1.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Background",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.0,
+                    0.7250000238418579,
+                    0.8849999904632568
+                  ],
+                  "State": 0,
+                  "Type": 0
+                }
+              ]
+            },
+            {
+              "AudioID": 13,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": false,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Canvas_Missions",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 511634923
+            },
+            {
+              "DebugDraw": true,
+              "Enabled": false,
+              "Name": "Canvas",
+              "ParentUID": 3452816845,
+              "Rect": [
+                0.0,
+                0.0,
+                2.0,
+                2.0
+              ],
+              "Type": 6,
+              "UID": 1944687447,
+              "UiElements": [
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2487634769,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_Dialogue",
+                  "Print": true,
+                  "Rect": [
+                    -0.35499998927116394,
+                    0.6299999952316284,
+                    0.03500000014901161,
+                    0.04500000178813934
+                  ],
+                  "State": 0,
+                  "TextString": "Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit,\nsed do eiusmod tempor\nincididunt ut labore et\ndolore magna aliqua. Id velit\nut tortor pretium viverra.",
+                  "Type": 4
+                },
+                {
+                  "ID": 170723650,
+                  "ImagePath": "Assets/Textures/Hud/Dialogue_Screen_Profiles_SpriteSheet.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    0.3223031163215637,
+                    0.49300700426101685
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_ShopKeeper",
+                  "Print": true,
+                  "Rect": [
+                    0.7300000190734863,
+                    -0.18000000715255737,
+                    0.26499998569488525,
+                    0.26499998569488525
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 3099788797,
+                  "ImagePath": "Assets/Textures/Hud/Dialogue_Screen_Profiles_SpriteSheet.png",
+                  "ImageSection": [
+                    0.0,
+                    0.503496527671814,
+                    0.3223031163215637,
+                    0.49300700426101685
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Medic",
+                  "Print": false,
+                  "Rect": [
+                    0.7300000190734863,
+                    -0.1899999976158142,
+                    0.26499998569488525,
+                    0.26499998569488525
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 1050211218,
+                  "ImagePath": "Assets/Textures/Hud/Dialogue_Screen_Profiles_SpriteSheet.png",
+                  "ImageSection": [
+                    0.33884844183921814,
+                    0.0,
+                    0.3223031163215637,
+                    0.49300700426101685
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_CampLeader",
+                  "Print": false,
+                  "Rect": [
+                    0.7300000190734863,
+                    -0.18000000715255737,
+                    0.26499998569488525,
+                    0.26499998569488525
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 883515064,
+                  "ImagePath": "Assets/Textures/Hud/Dialogue_Screen_Profiles_SpriteSheet.png",
+                  "ImageSection": [
+                    0.33884844183921814,
+                    0.503496527671814,
+                    0.3223031163215637,
+                    0.49300700426101685
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Sargeant",
+                  "Print": false,
+                  "Rect": [
+                    0.7300000190734863,
+                    -0.18000000715255737,
+                    0.26499998569488525,
+                    0.26499998569488525
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 275385601,
+                  "ImagePath": "Assets/Textures/Hud/Dialogue_Screen_Box_SpriteSheet.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    1.0,
+                    1.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_DialogueBox",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.7450000047683716,
+                    0.4000000059604645,
+                    0.25999999046325684
+                  ],
+                  "State": 0,
+                  "Type": 0
+                }
+              ]
+            },
+            {
+              "AudioID": 14,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": false,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Canvas_Dialogue",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 2109956043
+            },
+            {
+              "DebugDraw": true,
+              "Enabled": false,
+              "Name": "Canvas",
+              "ParentUID": 3452816845,
+              "Rect": [
+                0.0,
+                0.0,
+                2.0,
+                2.0
+              ],
+              "Type": 6,
+              "UID": 3801842989,
+              "UiElements": [
+                {
+                  "ID": 2625849279,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.0,
+                    0.7142857313156128,
+                    0.29954615235328674,
+                    0.08775509893894196
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_StatUpgradesTitle",
+                  "Print": true,
+                  "Rect": [
+                    -0.5149999856948853,
+                    -0.6600000262260437,
+                    0.22499999403953552,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 887949198,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.009077155962586403,
+                    0.8693877458572388,
+                    0.06505294889211655,
+                    0.12244898080825806
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_CurrentCurrencyIcon",
+                  "Print": true,
+                  "Rect": [
+                    0.3499999940395355,
+                    -0.6800000071525574,
+                    0.05999999865889549,
+                    0.06499999761581421
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2784990497,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_CurrentCurrencyAmount",
+                  "Print": true,
+                  "Rect": [
+                    0.4300000071525574,
+                    -0.6349999904632568,
+                    0.054999999701976776,
+                    0.07500000298023224
+                  ],
+                  "State": 0,
+                  "TextString": "5000",
+                  "Type": 4
+                },
+                {
+                  "ID": 4075757284,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.00378214824013412,
+                    0.8102040886878967,
+                    0.9727685451507568,
+                    0.022448979318141937
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_GreenBar",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    -0.5899999737739563,
+                    0.7450000047683716,
+                    0.014999999664723873
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 1606800772,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    0.9727685451507568,
+                    0.022448979318141937
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_DamageYellowBar",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    -0.4699999988079071,
+                    0.7450000047683716,
+                    0.014999999664723873
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 837098649,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    0.9727685451507568,
+                    0.022448979318141937
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_HealthYellowBar",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    -0.07000000029802322,
+                    0.7450000047683716,
+                    0.014999999664723873
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 2444594422,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    0.9727685451507568,
+                    0.022448979318141937
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_SpeedYellowBar",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.3700000047683716,
+                    0.7450000047683716,
+                    0.014999999664723873
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 2636266365,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.827534019947052,
+                    0.08367346972227097,
+                    0.09531013667583466,
+                    0.059183672070503235
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_DamageTitle",
+                  "Print": true,
+                  "Rect": [
+                    -0.6299999952316284,
+                    -0.5,
+                    0.10999999940395355,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 1646066632,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.827534019947052,
+                    0.15918366611003876,
+                    0.09531013667583466,
+                    0.059183672070503235
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_HealthTitle",
+                  "Print": true,
+                  "Rect": [
+                    -0.6299999952316284,
+                    -0.10000000149011612,
+                    0.10999999940395355,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 687320634,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.827534019947052,
+                    0.23061224818229675,
+                    0.09531013667583466,
+                    0.059183672070503235
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_SpeedTitle",
+                  "Print": true,
+                  "Rect": [
+                    -0.6299999952316284,
+                    0.3400000035762787,
+                    0.10999999940395355,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 3162548390,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.646747350692749,
+                    0.0714285746216774,
+                    0.05673222243785858,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.646747350692749,
+                    0.2489795982837677,
+                    0.05673222243785858,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageIconLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.6600000262260437,
+                    -0.2750000059604645,
+                    0.03500000014901161,
+                    0.05999999865889549
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 2079892797,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.646747350692749,
+                    0.0714285746216774,
+                    0.05673222243785858,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.646747350692749,
+                    0.2489795982837677,
+                    0.05673222243785858,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageIconLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.30000001192092896,
+                    -0.2750000059604645,
+                    0.03500000014901161,
+                    0.05999999865889549
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 898212654,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.646747350692749,
+                    0.0714285746216774,
+                    0.05673222243785858,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.646747350692749,
+                    0.2489795982837677,
+                    0.05673222243785858,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageIconLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.08500000089406967,
+                    -0.2750000059604645,
+                    0.03500000014901161,
+                    0.05999999865889549
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 1605316063,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.646747350692749,
+                    0.0714285746216774,
+                    0.05673222243785858,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.646747350692749,
+                    0.2489795982837677,
+                    0.05673222243785858,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageIconLvl4",
+                  "Print": true,
+                  "Rect": [
+                    0.4350000023841858,
+                    -0.2750000059604645,
+                    0.03500000014901161,
+                    0.05999999865889549
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 1009443435,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.54841148853302,
+                    0.0714285746216774,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.5468986630439758,
+                    0.2489795982837677,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthIconLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.6600000262260437,
+                    0.1550000011920929,
+                    0.04500000178813934,
+                    0.06499999761581421
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 3586412451,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.54841148853302,
+                    0.0714285746216774,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.5468986630439758,
+                    0.2489795982837677,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthIconLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.30000001192092896,
+                    0.1550000011920929,
+                    0.04500000178813934,
+                    0.06499999761581421
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 3485283364,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.54841148853302,
+                    0.0714285746216774,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.5468986630439758,
+                    0.2489795982837677,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthIconLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.08500000089406967,
+                    0.1550000011920929,
+                    0.04500000178813934,
+                    0.06499999761581421
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 1264722428,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.54841148853302,
+                    0.0714285746216774,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.5468986630439758,
+                    0.2489795982837677,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthIconLvl4",
+                  "Print": true,
+                  "Rect": [
+                    0.4350000023841858,
+                    0.1550000011920929,
+                    0.04500000178813934,
+                    0.06499999761581421
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 808972213,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.7261724472045898,
+                    0.0714285746216774,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.7261724472045898,
+                    0.2489795982837677,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedIconLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.6600000262260437,
+                    0.625,
+                    0.04500000178813934,
+                    0.06499999761581421
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 1685852407,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.7261724472045898,
+                    0.0714285746216774,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.7261724472045898,
+                    0.2489795982837677,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedIconLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.30000001192092896,
+                    0.625,
+                    0.04500000178813934,
+                    0.06499999761581421
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 1575274375,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.7261724472045898,
+                    0.0714285746216774,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.7261724472045898,
+                    0.2489795982837677,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedIconLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.08500000089406967,
+                    0.625,
+                    0.04500000178813934,
+                    0.06499999761581421
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 2459328744,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.7261724472045898,
+                    0.0714285746216774,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionIdle": [
+                    0.7261724472045898,
+                    0.2489795982837677,
+                    0.07034795731306076,
+                    0.16734693944454193
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedIconLvl4",
+                  "Print": true,
+                  "Rect": [
+                    0.4350000023841858,
+                    0.625,
+                    0.04500000178813934,
+                    0.06499999761581421
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 160474440,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageLayerLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.6600000262260437,
+                    -0.2750000059604645,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 2609888491,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageLayerLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.30000001192092896,
+                    -0.2750000059604645,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 2422832144,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageLayerLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.08500000089406967,
+                    -0.2750000059604645,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 1838207713,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageLayerLvl4",
+                  "Print": true,
+                  "Rect": [
+                    0.4350000023841858,
+                    -0.2750000059604645,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 3011436480,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthLayerLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.6600000262260437,
+                    0.1550000011920929,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 4023450950,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthLayerLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.30000001192092896,
+                    0.1550000011920929,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 3959732063,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthLayerLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.08500000089406967,
+                    0.1550000011920929,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 1213524772,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthLayerLvl4",
+                  "Print": true,
+                  "Rect": [
+                    0.4350000023841858,
+                    0.1550000011920929,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 555723010,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedLayerLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.6600000262260437,
+                    0.6200000047683716,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 2672851644,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedLayerLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.30000001192092896,
+                    0.6200000047683716,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 920302970,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedLayerLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.08500000089406967,
+                    0.6200000047683716,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 251393799,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.005295007489621639,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionIdle": [
+                    0.14069591462612152,
+                    0.08571428805589676,
+                    0.11800302565097809,
+                    0.2836734652519226
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedLayerLvl4",
+                  "Print": true,
+                  "Rect": [
+                    0.4350000023841858,
+                    0.6200000047683716,
+                    0.07000000029802322,
+                    0.10999999940395355
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 2843720506,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.4183056056499481,
+                    0.08367346972227097,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionIdle": [
+                    0.4183056056499481,
+                    0.2612244784832001,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageArrowsLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.49000000953674316,
+                    -0.2750000059604645,
+                    0.10000000149011612,
+                    0.08500000089406967
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 3780602241,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.4183056056499481,
+                    0.08367346972227097,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionIdle": [
+                    0.4183056056499481,
+                    0.2612244784832001,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageArrowsLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.11500000208616257,
+                    -0.2750000059604645,
+                    0.10000000149011612,
+                    0.08500000089406967
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 1184538457,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.4183056056499481,
+                    0.08367346972227097,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionIdle": [
+                    0.4183056056499481,
+                    0.2612244784832001,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageArrowsLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.2549999952316284,
+                    -0.2750000059604645,
+                    0.10000000149011612,
+                    0.08500000089406967
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 2078565925,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.4183056056499481,
+                    0.08367346972227097,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionIdle": [
+                    0.4183056056499481,
+                    0.2612244784832001,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthArrowsLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.49000000953674316,
+                    0.1550000011920929,
+                    0.10000000149011612,
+                    0.08500000089406967
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 279961191,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.4183056056499481,
+                    0.08367346972227097,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionIdle": [
+                    0.4183056056499481,
+                    0.2612244784832001,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthArrowsLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.11500000208616257,
+                    0.1550000011920929,
+                    0.10000000149011612,
+                    0.08500000089406967
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 1788634707,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.4183056056499481,
+                    0.08367346972227097,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionIdle": [
+                    0.4183056056499481,
+                    0.2612244784832001,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthArrowsLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.2549999952316284,
+                    0.1550000011920929,
+                    0.10000000149011612,
+                    0.08500000089406967
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 10297130,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.4183056056499481,
+                    0.08367346972227097,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionIdle": [
+                    0.4183056056499481,
+                    0.2612244784832001,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedArrowsLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.49000000953674316,
+                    0.6200000047683716,
+                    0.10000000149011612,
+                    0.08500000089406967
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 558728995,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.4183056056499481,
+                    0.08367346972227097,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionIdle": [
+                    0.4183056056499481,
+                    0.2612244784832001,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedArrowsLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.11500000208616257,
+                    0.6200000047683716,
+                    0.10000000149011612,
+                    0.08500000089406967
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": false,
+                  "ID": 56033803,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.4183056056499481,
+                    0.08367346972227097,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionIdle": [
+                    0.4183056056499481,
+                    0.2612244784832001,
+                    0.11800302565097809,
+                    0.15714286267757416
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedArrowsLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.2549999952316284,
+                    0.6200000047683716,
+                    0.10000000149011612,
+                    0.08500000089406967
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "ID": 1105435765,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.009077155962586403,
+                    0.8693877458572388,
+                    0.06505294889211655,
+                    0.12244898080825806
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_DamageCurrencyIcon",
+                  "Print": true,
+                  "Rect": [
+                    0.5699999928474426,
+                    -0.1899999976158142,
+                    0.029999999329447746,
+                    0.03500000014901161
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 3061081040,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.009077155962586403,
+                    0.8693877458572388,
+                    0.06505294889211655,
+                    0.12244898080825806
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_HealthCurrencyIcon",
+                  "Print": true,
+                  "Rect": [
+                    0.5699999928474426,
+                    0.23499999940395355,
+                    0.029999999329447746,
+                    0.03500000014901161
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "ID": 3227671961,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSection": [
+                    0.009077155962586403,
+                    0.8693877458572388,
+                    0.06505294889211655,
+                    0.12244898080825806
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_SpeedCurrencyIcon",
+                  "Print": true,
+                  "Rect": [
+                    0.5699999928474426,
+                    0.699999988079071,
+                    0.029999999329447746,
+                    0.03500000014901161
+                  ],
+                  "State": 0,
+                  "Type": 0
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 4255723173,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_DamageCurrencyValue",
+                  "Print": true,
+                  "Rect": [
+                    0.6100000143051147,
+                    -0.17000000178813934,
+                    0.029999999329447746,
+                    0.054999999701976776
+                  ],
+                  "State": 0,
+                  "TextString": "100",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 1751644556,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_HealthCurrencyValue",
+                  "Print": true,
+                  "Rect": [
+                    0.6100000143051147,
+                    0.2549999952316284,
+                    0.029999999329447746,
+                    0.054999999701976776
+                  ],
+                  "State": 0,
+                  "TextString": "100",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 3151100563,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_SpeedCurrencyValue",
+                  "Print": true,
+                  "Rect": [
+                    0.6100000143051147,
+                    0.7200000286102295,
+                    0.029999999329447746,
+                    0.054999999701976776
+                  ],
+                  "State": 0,
+                  "TextString": "100",
+                  "Type": 4
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 236817145,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26323750615119934,
+                    0.24081632494926453,
+                    0.15355521440505981,
+                    0.13673469424247742
+                  ],
+                  "ImageSectionIdle": [
+                    0.26323750615119934,
+                    0.09795918315649033,
+                    0.15355521440505981,
+                    0.13673469424247742
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_DamageLvlUp",
+                  "Print": true,
+                  "Rect": [
+                    0.6050000190734863,
+                    -0.1850000023841858,
+                    0.11999999731779099,
+                    0.08500000089406967
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 1582076177,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26323750615119934,
+                    0.24081632494926453,
+                    0.15355521440505981,
+                    0.13673469424247742
+                  ],
+                  "ImageSectionIdle": [
+                    0.26323750615119934,
+                    0.09795918315649033,
+                    0.15355521440505981,
+                    0.13673469424247742
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_HealthLvlUp",
+                  "Print": true,
+                  "Rect": [
+                    0.6050000190734863,
+                    0.23999999463558197,
+                    0.11999999731779099,
+                    0.08500000089406967
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 526690301,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.26323750615119934,
+                    0.24081632494926453,
+                    0.15355521440505981,
+                    0.13673469424247742
+                  ],
+                  "ImageSectionIdle": [
+                    0.26323750615119934,
+                    0.09795918315649033,
+                    0.15355521440505981,
+                    0.13673469424247742
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_SpeedLvlUp",
+                  "Print": true,
+                  "Rect": [
+                    0.6050000190734863,
+                    0.7049999833106995,
+                    0.11999999731779099,
+                    0.08500000089406967
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    0.5350000262260437
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 663232167,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_DescriptionDamage",
+                  "Print": true,
+                  "Rect": [
+                    -0.7350000143051147,
+                    -0.41999998688697815,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "player damage increased by +10 per upgrade",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    0.5350000262260437
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2426187411,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_DescriptionHealth",
+                  "Print": true,
+                  "Rect": [
+                    -0.7350000143051147,
+                    -0.019999999552965164,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "player health increased by +20 per upgrade",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    0.5350000262260437
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 3709614906,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_DescriptionSpeed",
+                  "Print": true,
+                  "Rect": [
+                    -0.7350000143051147,
+                    0.42500001192092896,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "player speed increased by +?? per upgrade",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 650283236,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_DamageLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.6100000143051147,
+                    -0.3700000047683716,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl i",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 1073597933,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_DamageLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.24500000476837158,
+                    -0.3700000047683716,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl ii",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 1636675050,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_DamageLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.13500000536441803,
+                    -0.3700000047683716,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl iii",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2533293113,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_DamageLvl4",
+                  "Print": true,
+                  "Rect": [
+                    0.48500001430511475,
+                    -0.3700000047683716,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl iv",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2791469657,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_HealthLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.6100000143051147,
+                    0.054999999701976776,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl i",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2232809152,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_HealthLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.24500000476837158,
+                    0.054999999701976776,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl ii",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2406430594,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_HealthLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.13500000536441803,
+                    0.054999999701976776,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl iii",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 474498323,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_HealthLvl4",
+                  "Print": true,
+                  "Rect": [
+                    0.48500001430511475,
+                    0.054999999701976776,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl iv",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 3826009908,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_SpeedLvl1",
+                  "Print": true,
+                  "Rect": [
+                    -0.6100000143051147,
+                    0.5249999761581421,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl i",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 3545548352,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_SpeedLvl2",
+                  "Print": true,
+                  "Rect": [
+                    -0.24500000476837158,
+                    0.5249999761581421,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl ii",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2488488850,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_SpeedLvl3",
+                  "Print": true,
+                  "Rect": [
+                    0.13500000536441803,
+                    0.5249999761581421,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl iii",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2018747261,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_SpeedLvl4",
+                  "Print": true,
+                  "Rect": [
+                    0.48500001430511475,
+                    0.5249999761581421,
+                    0.02500000037252903,
+                    0.03999999910593033
+                  ],
+                  "State": 0,
+                  "TextString": "lvl iv",
+                  "Type": 4
+                },
+                {
+                  "ID": 572144032,
+                  "ImagePath": "Assets/Textures/Hud/Stats_Screen_Background.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    1.0,
+                    1.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Background",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.0,
+                    0.824999988079071,
+                    0.8849999904632568
+                  ],
+                  "State": 0,
+                  "Type": 0
+                }
+              ]
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "UiScriptStats",
+              "Type": 4,
+              "UID": 382180504
+            }
+          ],
+          "Enabled": false,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Canvas_Stats",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 2526864604
+            },
+            {
+              "DebugDraw": true,
+              "Enabled": false,
+              "Name": "Canvas",
+              "ParentUID": 3452816845,
+              "Rect": [
+                0.0,
+                0.0,
+                2.0,
+                2.0
+              ],
+              "Type": 6,
+              "UID": 289577509,
+              "UiElements": [
+                {
+                  "CountAsRealButton": true,
+                  "ID": 2615487896,
+                  "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.5559115409851074,
+                    0.0,
+                    0.054078828543424606,
+                    0.39830508828163147
+                  ],
+                  "ImageSectionIdle": [
+                    0.494958758354187,
+                    0.0,
+                    0.054078828543424606,
+                    0.39830508828163147
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_Controls",
+                  "Print": true,
+                  "Rect": [
+                    -0.7099999785423279,
+                    -0.45500001311302185,
+                    0.05999999865889549,
+                    0.38499999046325684
+                  ],
+                  "State": 1,
+                  "Type": 1
+                },
+                {
+                  "CountAsRealButton": true,
+                  "ID": 293137850,
+                  "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                  "ImageSectionHovered": [
+                    0.494958758354187,
+                    0.41148775815963745,
+                    0.054078828543424606,
+                    0.39830508828163147
+                  ],
+                  "ImageSectionIdle": [
+                    0.5559120178222656,
+                    0.41148775815963745,
+                    0.054078828543424606,
+                    0.39830508828163147
+                  ],
+                  "ImageSectionSelected": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Button_Display",
+                  "Print": true,
+                  "Rect": [
+                    -0.7099999785423279,
+                    0.38499999046325684,
+                    0.05999999865889549,
+                    0.38499999046325684
+                  ],
+                  "State": 0,
+                  "Type": 1
+                },
+                {
+                  "ID": 2516306616,
+                  "ImagePath": "Assets/Textures/Hud/Settings_Screen_Backgrounds.png",
+                  "ImageSection": [
+                    0.5685579180717468,
+                    0.0,
+                    0.4314420819282532,
+                    1.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Background",
+                  "Print": true,
+                  "Rect": [
+                    0.0,
+                    0.0,
+                    0.8500000238418579,
+                    1.0
+                  ],
+                  "State": 0,
+                  "Type": 0
+                }
+              ]
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "UiScriptSettings",
+              "Type": 4,
+              "UID": 415371177
+            }
+          ],
+          "Enabled": false,
+          "GameObjects": [
+            {
+              "Components": [
+                {
+                  "Name": "Transform",
+                  "Transformation Matrix": [
+                    1.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0
+                  ],
+                  "Type": 0,
+                  "UID": 2664389113
+                },
+                {
+                  "DebugDraw": true,
+                  "Enabled": false,
+                  "Name": "Canvas",
+                  "ParentUID": 3452816845,
+                  "Rect": [
+                    0.0,
+                    0.0,
+                    2.0,
+                    2.0
+                  ],
+                  "Type": 6,
+                  "UID": 2251431816,
+                  "UiElements": [
+                    {
+                      "ID": 2661435927,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.0,
+                        0.0,
+                        0.4945000112056732,
+                        0.5320150852203369
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_Controls",
+                      "Print": true,
+                      "Rect": [
+                        0.07999999821186066,
+                        -0.004999999888241291,
+                        0.6899999976158142,
+                        0.699999988079071
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    }
+                  ]
+                },
+                {
+                  "AudioID": 15,
+                  "Name": "AudioSource",
+                  "Type": 8
+                }
+              ],
+              "Enabled": false,
+              "HasTransparency": false,
+              "Keeped": false,
+              "Name": "Canvas_SettingsControls",
+              "ParentUID": 3452816845,
+              "Static": false,
+              "UID": 3452816845
+            },
+            {
+              "Components": [
+                {
+                  "Name": "Transform",
+                  "Transformation Matrix": [
+                    1.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0
+                  ],
+                  "Type": 0,
+                  "UID": 3122359830
+                },
+                {
+                  "DebugDraw": true,
+                  "Enabled": false,
+                  "Name": "Canvas",
+                  "ParentUID": 3452816845,
+                  "Rect": [
+                    0.0,
+                    0.0,
+                    2.0,
+                    2.0
+                  ],
+                  "Type": 6,
+                  "UID": 3969864301,
+                  "UiElements": [
+                    {
+                      "ID": 2748270331,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.01604033075273037,
+                        0.7325800657272339,
+                        0.1342804729938507,
+                        0.07062146812677383
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_Vsync",
+                      "Print": true,
+                      "Rect": [
+                        -0.2199999988079071,
+                        -0.5,
+                        0.1850000023841858,
+                        0.07000000029802322
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    },
+                    {
+                      "CheckerActive": true,
+                      "ID": 3977511478,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSectionHovered": [
+                        0.2740604877471924,
+                        0.5630885362625122,
+                        0.08432630449533463,
+                        0.16760829091072083
+                      ],
+                      "ImageSectionHoveredOff": [
+                        0.10219981521368027,
+                        0.5630885362625122,
+                        0.08432630449533463,
+                        0.16760829091072083
+                      ],
+                      "ImageSectionIdle": [
+                        0.18973419070243835,
+                        0.5630885362625122,
+                        0.08432630449533463,
+                        0.16760829091072083
+                      ],
+                      "ImageSectionIdleOff": [
+                        0.017873510718345642,
+                        0.5630885362625122,
+                        0.08432630449533463,
+                        0.16760829091072083
+                      ],
+                      "ImageSectionSelected": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageSectionSelectedOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "Interactuable": false,
+                      "Name": "Checker_Vsync",
+                      "Print": true,
+                      "Rect": [
+                        -0.48500001430511475,
+                        -0.5799999833106995,
+                        0.10499999672174454,
+                        0.15000000596046448
+                      ],
+                      "State": 0,
+                      "Type": 3
+                    },
+                    {
+                      "ID": 266551954,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.022456461563706398,
+                        0.8022598624229431,
+                        0.2355637103319168,
+                        0.07062146812677383
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_Fullscreen",
+                      "Print": true,
+                      "Rect": [
+                        0.48500001430511475,
+                        -0.5,
+                        0.2800000011920929,
+                        0.07000000029802322
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    },
+                    {
+                      "CheckerActive": false,
+                      "ID": 2697487097,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSectionHovered": [
+                        0.2740604877471924,
+                        0.5630885362625122,
+                        0.08432630449533463,
+                        0.16760829091072083
+                      ],
+                      "ImageSectionHoveredOff": [
+                        0.10219981521368027,
+                        0.5630885362625122,
+                        0.08432630449533463,
+                        0.16760829091072083
+                      ],
+                      "ImageSectionIdle": [
+                        0.18973419070243835,
+                        0.5630885362625122,
+                        0.08432630449533463,
+                        0.16760829091072083
+                      ],
+                      "ImageSectionIdleOff": [
+                        0.017873510718345642,
+                        0.5630885362625122,
+                        0.08432630449533463,
+                        0.16760829091072083
+                      ],
+                      "ImageSectionSelected": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageSectionSelectedOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "Interactuable": false,
+                      "Name": "Checker_Fullscreen",
+                      "Print": true,
+                      "Rect": [
+                        0.10499999672174454,
+                        -0.5799999833106995,
+                        0.10499999672174454,
+                        0.15000000596046448
+                      ],
+                      "State": 0,
+                      "Type": 3
+                    },
+                    {
+                      "ID": 3528987510,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.2717690169811249,
+                        0.7476459741592407,
+                        0.17736022174358368,
+                        0.0451977401971817
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_MainVolume",
+                      "Print": true,
+                      "Rect": [
+                        0.0,
+                        -0.23499999940395355,
+                        0.25999999046325684,
+                        0.054999999701976776
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    },
+                    {
+                      "AdditionalOffsetFirst": 0.0,
+                      "AdditionalOffsetLast": 0.0,
+                      "ID": 21305180,
+                      "ImageFirstSectionHovered": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionHoveredOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionIdle": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionIdleOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionSelected": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionSelectedOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionHovered": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionHoveredOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionIdle": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionIdleOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionSelected": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionSelectedOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSectionHovered": [
+                        0.461961954832077,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionHoveredOff": [
+                        0.5178735256195068,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionIdle": [
+                        0.02474793791770935,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionIdleOff": [
+                        0.07836847007274628,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionSelected": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageSectionSelectedOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "Interactuable": false,
+                      "MaxValue": 10,
+                      "MinValue": 0,
+                      "Name": "Slider_MainVolume",
+                      "Offset": 0.024000000208616257,
+                      "Print": true,
+                      "Rect": [
+                        -0.26499998569488525,
+                        -0.02500000037252903,
+                        0.07000000029802322,
+                        0.11500000208616257
+                      ],
+                      "SliderDesign": 0,
+                      "State": 0,
+                      "Type": 2,
+                      "Value": 10
+                    },
+                    {
+                      "ID": 2719489207,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.30109989643096924,
+                        0.9331449866294861,
+                        0.045829515904188156,
+                        0.034839924424886703
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_Minus_MainVolume",
+                      "Print": true,
+                      "Rect": [
+                        -0.4699999988079071,
+                        -0.014999999664723873,
+                        0.05000000074505806,
+                        0.029999999329447746
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    },
+                    {
+                      "ID": 538838834,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.22364802658557892,
+                        0.9209039807319641,
+                        0.045829515904188156,
+                        0.07721280306577682
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_Plus_MainVolume",
+                      "Print": true,
+                      "Rect": [
+                        0.4650000035762787,
+                        -0.014999999664723873,
+                        0.06499999761581421,
+                        0.08500000089406967
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    },
+                    {
+                      "ID": 1446147639,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.2717690169811249,
+                        0.8578154444694519,
+                        0.17736022174358368,
+                        0.0451977401971817
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_SFX",
+                      "Print": true,
+                      "Rect": [
+                        -0.20000000298023224,
+                        0.29499998688697815,
+                        0.25999999046325684,
+                        0.054999999701976776
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    },
+                    {
+                      "AdditionalOffsetFirst": 0.0,
+                      "AdditionalOffsetLast": 0.0,
+                      "ID": 1719812247,
+                      "ImageFirstSectionHovered": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionHoveredOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionIdle": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionIdleOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionSelected": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionSelectedOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionHovered": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionHoveredOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionIdle": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionIdleOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionSelected": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionSelectedOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSectionHovered": [
+                        0.461961954832077,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionHoveredOff": [
+                        0.5178735256195068,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionIdle": [
+                        0.02474793791770935,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionIdleOff": [
+                        0.07836847007274628,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionSelected": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageSectionSelectedOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "Interactuable": false,
+                      "MaxValue": 10,
+                      "MinValue": 0,
+                      "Name": "Slider_SFX",
+                      "Offset": -0.012000000104308128,
+                      "Print": true,
+                      "Rect": [
+                        -0.4449999928474426,
+                        0.45500001311302185,
+                        0.03999999910593033,
+                        0.06499999761581421
+                      ],
+                      "SliderDesign": 0,
+                      "State": 0,
+                      "Type": 2,
+                      "Value": 10
+                    },
+                    {
+                      "ID": 3091059169,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.30109989643096924,
+                        0.9331449866294861,
+                        0.045829515904188156,
+                        0.034839924424886703
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_Minus_SFX",
+                      "Print": true,
+                      "Rect": [
+                        -0.5600000023841858,
+                        0.46000000834465027,
+                        0.03500000014901161,
+                        0.019999999552965164
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    },
+                    {
+                      "ID": 3597133138,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.22364802658557892,
+                        0.9209039807319641,
+                        0.045829515904188156,
+                        0.07721280306577682
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_Plus_SFX",
+                      "Print": true,
+                      "Rect": [
+                        -0.05000000074505806,
+                        0.46000000834465027,
+                        0.04500000178813934,
+                        0.05999999865889549
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    },
+                    {
+                      "ID": 3618976250,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.2717690169811249,
+                        0.8088512420654297,
+                        0.17736022174358368,
+                        0.0451977401971817
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_Music",
+                      "Print": true,
+                      "Rect": [
+                        0.5149999856948853,
+                        0.29499998688697815,
+                        0.25999999046325684,
+                        0.054999999701976776
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    },
+                    {
+                      "AdditionalOffsetFirst": 0.0,
+                      "AdditionalOffsetLast": 0.0,
+                      "ID": 1704620755,
+                      "ImageFirstSectionHovered": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionHoveredOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionIdle": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionIdleOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionSelected": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageFirstSectionSelectedOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionHovered": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionHoveredOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionIdle": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionIdleOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionSelected": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageLastSectionSelectedOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSectionHovered": [
+                        0.461961954832077,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionHoveredOff": [
+                        0.5178735256195068,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionIdle": [
+                        0.02474793791770935,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionIdleOff": [
+                        0.07836847007274628,
+                        0.887005627155304,
+                        0.04995417222380638,
+                        0.10546139627695084
+                      ],
+                      "ImageSectionSelected": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "ImageSectionSelectedOff": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                      ],
+                      "Interactuable": false,
+                      "MaxValue": 10,
+                      "MinValue": 0,
+                      "Name": "Slider_Music",
+                      "Offset": -0.012000000104308128,
+                      "Print": true,
+                      "Rect": [
+                        0.3100000023841858,
+                        0.45500001311302185,
+                        0.03999999910593033,
+                        0.06499999761581421
+                      ],
+                      "SliderDesign": 0,
+                      "State": 0,
+                      "Type": 2,
+                      "Value": 10
+                    },
+                    {
+                      "ID": 2377133722,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.30109989643096924,
+                        0.9331449866294861,
+                        0.045829515904188156,
+                        0.034839924424886703
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_Minus_Music",
+                      "Print": true,
+                      "Rect": [
+                        0.17000000178813934,
+                        0.46000000834465027,
+                        0.03500000014901161,
+                        0.019999999552965164
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    },
+                    {
+                      "ID": 2742457731,
+                      "ImagePath": "Assets/Textures/Hud/Settings_Screen_SpriteSheet.png",
+                      "ImageSection": [
+                        0.22364802658557892,
+                        0.9209039807319641,
+                        0.045829515904188156,
+                        0.07721280306577682
+                      ],
+                      "Interactuable": false,
+                      "Name": "Img_Plus_Music",
+                      "Print": true,
+                      "Rect": [
+                        0.7099999785423279,
+                        0.46000000834465027,
+                        0.04500000178813934,
+                        0.05999999865889549
+                      ],
+                      "State": 0,
+                      "Type": 0
+                    }
+                  ]
+                },
+                {
+                  "Name": "Script",
+                  "ParentUID": 3452816845,
+                  "ScriptName": "UiScriptSettingsDisplay",
+                  "Type": 4,
+                  "UID": 1616070798
+                },
+                {
+                  "AudioID": 16,
+                  "Name": "AudioSource",
+                  "Type": 8
+                }
+              ],
+              "Enabled": false,
+              "HasTransparency": false,
+              "Keeped": false,
+              "Name": "Canvas_SettingsDisplay",
+              "ParentUID": 3452816845,
+              "Static": false,
+              "UID": 3452816845
+            }
+          ],
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Canvas_Settings",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 4292751725
+            },
+            {
+              "DebugDraw": true,
+              "Enabled": false,
+              "Name": "Canvas",
+              "ParentUID": 3452816845,
+              "Rect": [
+                0.0,
+                0.0,
+                2.0,
+                2.0
+              ],
+              "Type": 6,
+              "UID": 27801636,
+              "UiElements": [
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 619681716,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_SavingProgress",
+                  "Print": true,
+                  "Rect": [
+                    -0.8999999761581421,
+                    0.949999988079071,
+                    0.03999999910593033,
+                    0.07000000029802322
+                  ],
+                  "State": 0,
+                  "TextString": "saving progress...",
+                  "Type": 4
+                },
+                {
+                  "ID": 2475109732,
+                  "ImagePath": "Assets\\Textures\\Hud\\GameIcon.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    1.0,
+                    1.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_SavingIcon",
+                  "Print": true,
+                  "Rect": [
+                    -0.949999988079071,
+                    0.9150000214576721,
+                    0.03500000014901161,
+                    0.06499999761581421
+                  ],
+                  "State": 0,
+                  "Type": 0
+                }
+              ]
+            },
+            {
+              "AudioID": 17,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": false,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Canvas_SavingScene",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 3712653715
+            },
+            {
+              "DebugDraw": true,
+              "Enabled": false,
+              "Name": "Canvas",
+              "ParentUID": 3452816845,
+              "Rect": [
+                0.0,
+                0.0,
+                2.0,
+                2.0
+              ],
+              "Type": 6,
+              "UID": 2755791311,
+              "UiElements": [
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    0.009999999776482582,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 2770986528,
+                  "Interactuable": false,
+                  "Kerning": 0.0,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_TitleNewItem",
+                  "Print": true,
+                  "Rect": [
+                    -0.925000011920929,
+                    0.6150000095367432,
+                    0.03500000014901161,
+                    0.06499999761581421
+                  ],
+                  "State": 0,
+                  "TextString": "New item:",
+                  "Type": 4
+                },
+                {
+                  "Color": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "FontPath": "Assets/Fonts/AlienInvader.ttf",
+                  "ID": 1456410993,
+                  "Interactuable": false,
+                  "Kerning": 0.014999999664723873,
+                  "LineSpacing": 0.0,
+                  "Name": "Text_PickedItem",
+                  "Print": true,
+                  "Rect": [
+                    -0.925000011920929,
+                    0.6949999928474426,
+                    0.029999999329447746,
+                    0.05000000074505806
+                  ],
+                  "State": 0,
+                  "TextString": "shoulder laser",
+                  "Type": 4
+                },
+                {
+                  "ID": 3957239493,
+                  "ImagePath": "Assets\\Textures\\Hud\\Dialogue_Screen_Box_SpriteSheet.png",
+                  "ImageSection": [
+                    0.0,
+                    0.0,
+                    1.0,
+                    1.0
+                  ],
+                  "Interactuable": false,
+                  "Name": "Img_Background",
+                  "Print": true,
+                  "Rect": [
+                    -0.7149999737739563,
+                    0.6449999809265137,
+                    0.25,
+                    0.17000000178813934
+                  ],
+                  "State": 0,
+                  "Type": 0
+                }
+              ]
+            },
+            {
+              "AudioID": 18,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": false,
+          "HasTransparency": false,
+          "Keeped": false,
+          "Name": "Canvas_PickUpFeedback",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 762181437
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "GameManager",
+              "Type": 4,
+              "UID": 2135104260
+            },
+            {
+              "AudioID": 19,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": true,
+          "Name": "GameManager",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        },
+        {
+          "Components": [
+            {
+              "Name": "Transform",
+              "Transformation Matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+              ],
+              "Type": 0,
+              "UID": 2278715941
+            },
+            {
+              "Name": "Script",
+              "ParentUID": 3452816845,
+              "ScriptName": "ItemManager",
+              "Type": 4,
+              "UID": 2581454987
+            },
+            {
+              "AudioID": 20,
+              "Name": "AudioSource",
+              "Type": 8
+            }
+          ],
+          "Enabled": true,
+          "HasTransparency": false,
+          "Keeped": true,
+          "Name": "ItemManager",
+          "ParentUID": 3452816845,
+          "Static": false,
+          "UID": 3452816845
+        }
+      ],
+      "HasTransparency": false,
+      "Keeped": false,
+      "Name": "UI_Manager",
+      "ParentUID": 69993984,
+      "PrefabDirty": false,
+      "PrefabID": 2472160759,
+      "PrefabName": "UI_Manager",
       "Static": false,
       "UID": 3452816845
     }

--- a/TheOneEditor/Assets/Scenes/L1R1.toe
+++ b/TheOneEditor/Assets/Scenes/L1R1.toe
@@ -48,7 +48,7 @@
           "UID": 608360335
         },
         {
-          "AudioID": 25,
+          "AudioID": 0,
           "Name": "Listener",
           "Type": 7
         }
@@ -57,7 +57,7 @@
       "HasTransparency": false,
       "Keeped": false,
       "Name": "mainCamera",
-      "ParentUID": 3452816845,
+      "ParentUID": 5374032,
       "Static": false,
       "UID": 3452816845
     },
@@ -1273,7 +1273,7 @@
       "HasTransparency": false,
       "Keeped": false,
       "Name": "Fire_Particles",
-      "ParentUID": 3452816845,
+      "ParentUID": 5374032,
       "Static": false,
       "UID": 3452816845
     },
@@ -1765,7 +1765,7 @@
       "HasTransparency": false,
       "Keeped": false,
       "Name": "Sparks_Particles",
-      "ParentUID": 3452816845,
+      "ParentUID": 5374032,
       "Static": false,
       "UID": 3452816845
     },
@@ -25750,7 +25750,7 @@
       "HasTransparency": false,
       "Keeped": false,
       "Name": "L1R1",
-      "ParentUID": 3452816845,
+      "ParentUID": 5374032,
       "Static": false,
       "UID": 3452816845
     },
@@ -25802,7 +25802,7 @@
           "UID": 225613267
         },
         {
-          "AudioID": 26,
+          "AudioID": 1,
           "Name": "AudioSource",
           "Type": 8
         },
@@ -26209,7 +26209,7 @@
               "UID": 3667515160
             },
             {
-              "AudioID": 27,
+              "AudioID": 2,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -26255,7 +26255,7 @@
               "UID": 1177981766
             },
             {
-              "AudioID": 28,
+              "AudioID": 3,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -26301,7 +26301,7 @@
               "UID": 2174904043
             },
             {
-              "AudioID": 29,
+              "AudioID": 4,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -26347,7 +26347,7 @@
               "UID": 2232833499
             },
             {
-              "AudioID": 30,
+              "AudioID": 5,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -26393,7 +26393,7 @@
               "UID": 2199890485
             },
             {
-              "AudioID": 31,
+              "AudioID": 6,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -26439,7 +26439,7 @@
               "UID": 3061441302
             },
             {
-              "AudioID": 32,
+              "AudioID": 7,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -26485,7 +26485,7 @@
               "UID": 1809667645
             },
             {
-              "AudioID": 33,
+              "AudioID": 8,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -26502,7 +26502,7 @@
       "HasTransparency": false,
       "Keeped": false,
       "Name": "SK_MainCharacter",
-      "ParentUID": 3452816845,
+      "ParentUID": 5374032,
       "PrefabDirty": true,
       "PrefabID": 186710944,
       "PrefabName": "SK_MainCharacter",
@@ -26542,7 +26542,7 @@
           "UID": 2371490470
         },
         {
-          "AudioID": 34,
+          "AudioID": 9,
           "Name": "AudioSource",
           "Type": 8
         }
@@ -27643,7 +27643,7 @@
               "UID": 951121546
             },
             {
-              "AudioID": 35,
+              "AudioID": 10,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -27944,7 +27944,7 @@
               ]
             },
             {
-              "AudioID": 36,
+              "AudioID": 11,
               "Name": "Source",
               "Type": 8
             },
@@ -29509,7 +29509,7 @@
               "UID": 607510851
             },
             {
-              "AudioID": 37,
+              "AudioID": 12,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -30008,7 +30008,7 @@
               ]
             },
             {
-              "AudioID": 38,
+              "AudioID": 13,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -30192,7 +30192,7 @@
               ]
             },
             {
-              "AudioID": 39,
+              "AudioID": 14,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -32418,7 +32418,7 @@
                   ]
                 },
                 {
-                  "AudioID": 40,
+                  "AudioID": 15,
                   "Name": "AudioSource",
                   "Type": 8
                 }
@@ -33205,7 +33205,7 @@
                   "UID": 1616070798
                 },
                 {
-                  "AudioID": 41,
+                  "AudioID": 16,
                   "Name": "AudioSource",
                   "Type": 8
                 }
@@ -33313,7 +33313,7 @@
               ]
             },
             {
-              "AudioID": 42,
+              "AudioID": 17,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -33437,7 +33437,7 @@
               ]
             },
             {
-              "AudioID": 43,
+              "AudioID": 18,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -33483,7 +33483,7 @@
               "UID": 2135104260
             },
             {
-              "AudioID": 44,
+              "AudioID": 19,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -33529,7 +33529,7 @@
               "UID": 2581454987
             },
             {
-              "AudioID": 45,
+              "AudioID": 20,
               "Name": "AudioSource",
               "Type": 8
             }
@@ -33541,58 +33541,12 @@
           "ParentUID": 3452816845,
           "Static": false,
           "UID": 3452816845
-        },
-        {
-          "Components": [
-            {
-              "Name": "Transform",
-              "Transformation Matrix": [
-                1.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                1.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                1.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                1.0
-              ],
-              "Type": 0,
-              "UID": 4072698855
-            },
-            {
-              "Name": "Script",
-              "ParentUID": 3452816845,
-              "ScriptName": "ItemManager",
-              "Type": 4,
-              "UID": 1110714302
-            },
-            {
-              "AudioID": 46,
-              "Name": "AudioSource",
-              "Type": 8
-            }
-          ],
-          "Enabled": true,
-          "HasTransparency": false,
-          "Keeped": false,
-          "Name": "Manager",
-          "ParentUID": 3452816845,
-          "Static": false,
-          "UID": 3452816845
         }
       ],
       "HasTransparency": false,
       "Keeped": false,
       "Name": "UI_Manager",
-      "ParentUID": 3452816845,
+      "ParentUID": 5374032,
       "PrefabDirty": false,
       "PrefabID": 2472160759,
       "PrefabName": "UI_Manager",
@@ -33647,7 +33601,7 @@
           "UID": 3318160678
         },
         {
-          "AudioID": 47,
+          "AudioID": 21,
           "Name": "AudioSource",
           "Type": 8
         },
@@ -33672,7 +33626,7 @@
       "HasTransparency": false,
       "Keeped": false,
       "Name": "SK_Anarchist (1)",
-      "ParentUID": 3452816845,
+      "ParentUID": 5374032,
       "PrefabDirty": false,
       "PrefabID": 3633985190,
       "PrefabName": "SK_Anarchist",
@@ -33716,7 +33670,7 @@
       "HasTransparency": false,
       "Keeped": false,
       "Name": "SwapScene_L1_R2",
-      "ParentUID": 3452816845,
+      "ParentUID": 5374032,
       "Static": false,
       "UID": 3452816845
     },
@@ -33787,7 +33741,7 @@
       "HasTransparency": false,
       "Keeped": false,
       "Name": "WP_CarabinaM4",
-      "ParentUID": 3452816845,
+      "ParentUID": 5374032,
       "Static": false,
       "UID": 6881399
     }

--- a/TheOneEditor/imgui.ini
+++ b/TheOneEditor/imgui.ini
@@ -51,7 +51,7 @@ Collapsed=0
 DockId=0x00000002,0
 
 [Window][Scene(s) Have Been Modified]
-Pos=767,422
+Pos=447,278
 Size=386,164
 Collapsed=0
 

--- a/TheOneEditor/imgui.ini
+++ b/TheOneEditor/imgui.ini
@@ -51,7 +51,7 @@ Collapsed=0
 DockId=0x00000002,0
 
 [Window][Scene(s) Have Been Modified]
-Pos=447,278
+Pos=767,422
 Size=386,164
 Collapsed=0
 

--- a/TheOneEngine/MonoManager.cpp
+++ b/TheOneEngine/MonoManager.cpp
@@ -149,7 +149,7 @@ void* MonoManager::CallScriptFunction(MonoObject* monoBehaviourInstance, std::st
     if (method == nullptr)
     {
         //Used for handling virtual functions errors
-        for (auto checkFunction : functionsToIgnore)
+        for (auto& checkFunction : functionsToIgnore)
         {
             if (functionToCall == checkFunction) return nullptr;
         }
@@ -226,14 +226,14 @@ void MonoManager::RenderShapesQueue()
     if (debugShapesQueue.empty())
         return;
 
-    for (auto shape : debugShapesQueue)
+    for (auto& shape : debugShapesQueue)
     {
         glPushMatrix();
         glTranslatef(shape.center.x, shape.center.y, shape.center.z);
         glColor3f(shape.color.r, shape.color.g, shape.color.b);
         glBegin(GL_LINE_LOOP);
 
-        for (auto point : shape.points)
+        for (auto& point : shape.points)
             glVertex3f(point.x, point.y, point.z);
 
         glEnd();

--- a/TheOneEngine/MonoRegisterer.cpp
+++ b/TheOneEngine/MonoRegisterer.cpp
@@ -691,6 +691,8 @@ static void SetTextString(GameObject* containerGO, MonoString* text, MonoString*
 	Canvas* canvas = containerGO->GetComponent<Canvas>();
 
 	std::string itemName = MonoRegisterer::MonoStringToUTF8(name);
+	std::string itemText = MonoRegisterer::MonoStringToUTF8(text);
+
 	std::vector<ItemUI*> uiElements = canvas->GetUiElements();
 
 	for (auto element : uiElements)
@@ -698,7 +700,7 @@ static void SetTextString(GameObject* containerGO, MonoString* text, MonoString*
 		if (element->GetType() == UiType::TEXT && element->GetName() == itemName)
 		{
 			TextUI* ui = canvas->GetItemUI<TextUI>(element->GetID());
-			ui->SetText(itemName);
+			ui->SetText(itemText);
 			break;
 		}
 	}

--- a/TheOneEngine/MonoRegisterer.cpp
+++ b/TheOneEngine/MonoRegisterer.cpp
@@ -152,11 +152,7 @@ static GameObject* InstantiateGrenade(vec3f* initialPosition, vec3f* direction)
 	SetRotation(go, direction);
 
 	go->AddScript("Grenade");
-	//go->AddComponent<Collider2D>();
-	//go->GetComponent<Collider2D>()->colliderType = ColliderType::Circle;
-	//go->GetComponent<Collider2D>()->collisionType = CollisionType::Bullet;
-	//go->GetComponent<Collider2D>()->radius = 0.4f;
-	//engine->collisionSolver->LoadCollisions(engine->N_sceneManager->objectsToAdd.back());
+
 	return go;
 }
 
@@ -175,7 +171,7 @@ static GameObject* InstantiateXenomorph(vec3f* initialPosition, vec3f* direction
 	go->GetComponent<Collider2D>()->radius = 30.0f;
 
 	go->AddComponent<AudioSource>();
-	
+
 	go->AddScript("FaceHuggerBehaviour");
 
 	return go;
@@ -195,7 +191,7 @@ static GameObject* RecursiveFindGO(std::string _name, GameObject* refGO)
 {
 	GameObject* returnedGO = nullptr;
 
-	for (auto go : refGO->children)
+	for (auto& go : refGO->children)
 	{
 		if (go->GetName() == _name)
 		{
@@ -240,8 +236,8 @@ static void* ComponentCheck(GameObject* GOptr, int componentType, MonoString* sc
 	else if (scriptName != nullptr)
 	{
 		std::string scriptToFind = MonoRegisterer::MonoStringToUTF8(scriptName);
-		
-		for (auto comp: GOptr->GetAllComponents())
+
+		for (auto comp : GOptr->GetAllComponents())
 		{
 			if (comp->GetType() == ComponentType::Script)
 			{
@@ -289,7 +285,7 @@ static void LoadScene(MonoString* sceneName, bool keep, MonoString* path)
 	std::string name = MonoRegisterer::MonoStringToUTF8(sceneName);
 	std::string filepath = MonoRegisterer::MonoStringToUTF8(path);
 
-	if(keep)
+	if (keep)
 		engine->N_sceneManager->LoadSave(name, filepath);
 	else
 		engine->N_sceneManager->LoadScene(name);
@@ -440,6 +436,8 @@ static void CanvasEnableToggle(GameObject* containerGO)
 
 static void ToggleChecker(GameObject* containerGO, bool value, MonoString* nameM)
 {
+	Canvas* canvas = containerGO->GetComponent<Canvas>();
+
 	std::string name = MonoRegisterer::MonoStringToUTF8(nameM);
 
 	std::vector<ItemUI*> uiElements = containerGO->GetComponent<Canvas>()->GetUiElements();
@@ -447,13 +445,15 @@ static void ToggleChecker(GameObject* containerGO, bool value, MonoString* nameM
 	{
 		if (uiElements[i]->GetType() == UiType::CHECKER && uiElements[i]->GetName() == name)
 		{
-			containerGO->GetComponent<Canvas>()->GetItemUI<CheckerUI>(uiElements[i]->GetID())->SetChecker(value);
+			canvas->GetItemUI<CheckerUI>(uiElements[i]->GetID())->SetChecker(value);
 		}
 	}
 }
 
 static void PrintItemUI(GameObject* containerGO, bool value, MonoString* nameM)
 {
+	Canvas* canvas = containerGO->GetComponent<Canvas>();
+
 	std::string name = MonoRegisterer::MonoStringToUTF8(nameM);
 
 	std::vector<ItemUI*> uiElements = containerGO->GetComponent<Canvas>()->GetUiElements();
@@ -461,7 +461,7 @@ static void PrintItemUI(GameObject* containerGO, bool value, MonoString* nameM)
 	{
 		if (uiElements[i]->GetName() == name)
 		{
-			containerGO->GetComponent<Canvas>()->GetItemUI<ItemUI>(uiElements[i]->GetID())->SetPrint(value);
+			canvas->GetItemUI<ItemUI>(uiElements[i]->GetID())->SetPrint(value);
 		}
 	}
 }
@@ -619,13 +619,15 @@ static void MoveSelection(GameObject* containerGO, int direction)
 
 static void ChangeSectImg(GameObject* containerGO, MonoString* name, int x, int y, int w, int h)
 {
+	Canvas* canvas = containerGO->GetComponent<Canvas>();
+
 	std::string itemName = MonoRegisterer::MonoStringToUTF8(name);
-	std::vector<ItemUI*> uiElements = containerGO->GetComponent<Canvas>()->GetUiElements();
+	std::vector<ItemUI*> uiElements = canvas->GetUiElements();
 	for (size_t i = 0; i < uiElements.size(); i++)
 	{
 		if (uiElements[i]->GetType() == UiType::IMAGE && uiElements[i]->GetName() == itemName)
 		{
-			ImageUI* ui = containerGO->GetComponent<Canvas>()->GetItemUI<ImageUI>(uiElements[i]->GetID());
+			ImageUI* ui = canvas->GetItemUI<ImageUI>(uiElements[i]->GetID());
 			ui->SetSectSize(x, y, w, h);
 		}
 	}
@@ -633,13 +635,15 @@ static void ChangeSectImg(GameObject* containerGO, MonoString* name, int x, int 
 
 static int GetSliderValue(GameObject* containerGO, MonoString* name)
 {
+	Canvas* canvas = containerGO->GetComponent<Canvas>();
+
 	std::string itemName = MonoRegisterer::MonoStringToUTF8(name);
-	std::vector<ItemUI*> uiElements = containerGO->GetComponent<Canvas>()->GetUiElements();
+	std::vector<ItemUI*> uiElements = canvas->GetUiElements();
 	for (size_t i = 0; i < uiElements.size(); i++)
 	{
 		if (uiElements[i]->GetType() == UiType::SLIDER && uiElements[i]->GetName() == itemName)
 		{
-			SliderUI* ui = containerGO->GetComponent<Canvas>()->GetItemUI<SliderUI>(uiElements[i]->GetID());
+			SliderUI* ui = canvas->GetItemUI<SliderUI>(uiElements[i]->GetID());
 			return ui->GetValue();
 		}
 	}
@@ -649,13 +653,15 @@ static int GetSliderValue(GameObject* containerGO, MonoString* name)
 
 static int GetSliderMaxValue(GameObject* containerGO, MonoString* name)
 {
+	Canvas* canvas = containerGO->GetComponent<Canvas>();
+
 	std::string itemName = MonoRegisterer::MonoStringToUTF8(name);
-	std::vector<ItemUI*> uiElements = containerGO->GetComponent<Canvas>()->GetUiElements();
+	std::vector<ItemUI*> uiElements = canvas->GetUiElements();
 	for (size_t i = 0; i < uiElements.size(); i++)
 	{
 		if (uiElements[i]->GetType() == UiType::SLIDER && uiElements[i]->GetName() == itemName)
 		{
-			SliderUI* ui = containerGO->GetComponent<Canvas>()->GetItemUI<SliderUI>(uiElements[i]->GetID());
+			SliderUI* ui = canvas->GetItemUI<SliderUI>(uiElements[i]->GetID());
 			return ui->GetMaxValue();
 		}
 	}
@@ -665,13 +671,15 @@ static int GetSliderMaxValue(GameObject* containerGO, MonoString* name)
 
 static void SetSliderValue(GameObject* containerGO, int value, MonoString* name)
 {
+	Canvas* canvas = containerGO->GetComponent<Canvas>();
+
 	std::string itemName = MonoRegisterer::MonoStringToUTF8(name);
-	std::vector<ItemUI*> uiElements = containerGO->GetComponent<Canvas>()->GetUiElements();
+	std::vector<ItemUI*> uiElements = canvas->GetUiElements();
 	for (size_t i = 0; i < uiElements.size(); i++)
 	{
 		if (uiElements[i]->GetType() == UiType::SLIDER && uiElements[i]->GetName() == itemName)
 		{
-			SliderUI* ui = containerGO->GetComponent<Canvas>()->GetItemUI<SliderUI>(uiElements[i]->GetID());
+			SliderUI* ui = canvas->GetItemUI<SliderUI>(uiElements[i]->GetID());
 			ui->SetValue(value);
 			break;
 		}
@@ -680,14 +688,17 @@ static void SetSliderValue(GameObject* containerGO, int value, MonoString* name)
 
 static void SetTextString(GameObject* containerGO, MonoString* text, MonoString* name)
 {
+	Canvas* canvas = containerGO->GetComponent<Canvas>();
+
 	std::string itemName = MonoRegisterer::MonoStringToUTF8(name);
-	std::vector<ItemUI*> uiElements = containerGO->GetComponent<Canvas>()->GetUiElements();
-	for (size_t i = 0; i < uiElements.size(); i++)
+	std::vector<ItemUI*> uiElements = canvas->GetUiElements();
+
+	for (auto element : uiElements)
 	{
-		if (uiElements[i]->GetType() == UiType::TEXT && uiElements[i]->GetName() == itemName)
+		if (element->GetType() == UiType::TEXT && element->GetName() == itemName)
 		{
-			TextUI* ui = containerGO->GetComponent<Canvas>()->GetItemUI<TextUI>(uiElements[i]->GetID());
-			ui->SetText(MonoRegisterer::MonoStringToUTF8(text));
+			TextUI* ui = canvas->GetItemUI<TextUI>(element->GetID());
+			ui->SetText(itemName);
 			break;
 		}
 	}
@@ -695,14 +706,16 @@ static void SetTextString(GameObject* containerGO, MonoString* text, MonoString*
 
 static MonoString* GetTextString(GameObject* containerGO, MonoString* name)
 {
+	Canvas* canvas = containerGO->GetComponent<Canvas>();
+
 	std::string itemName = MonoRegisterer::MonoStringToUTF8(name);
-	std::vector<ItemUI*> uiElements = containerGO->GetComponent<Canvas>()->GetUiElements();
+	std::vector<ItemUI*> uiElements = canvas->GetUiElements();
 	std::string ret = "TextUI element not found";
 	for (size_t i = 0; i < uiElements.size(); i++)
 	{
 		if (uiElements[i]->GetType() == UiType::TEXT && uiElements[i]->GetName() == itemName)
 		{
-			TextUI* ui = containerGO->GetComponent<Canvas>()->GetItemUI<TextUI>(uiElements[i]->GetID());
+			TextUI* ui = canvas->GetItemUI<TextUI>(uiElements[i]->GetID());
 			return mono_string_new(MonoManager::GetAppDomain(), ui->GetText().c_str());
 		}
 	}
@@ -769,7 +782,7 @@ static void DrawWireSphere(vec3f position, float radius, vec3f colorNormalized)
 		float y = radius * sinf(angle);
 		shapeToAdd.points.push_back(vec3f(x, y, 0));
 	}
-	
+
 	//Go to starting spot for last circle
 	for (int i = 0; i < segments / 4; ++i) {
 		float angle = 2.0f * 3.14159f * float(i) / float(segments);
@@ -966,7 +979,7 @@ static bool AnimationHasFinished(GameObject* GOptr)
 	return false;
 }
 
-static bool GetTransitionBlend(GameObject* GOptr){
+static bool GetTransitionBlend(GameObject* GOptr) {
 	Model* m = Resources::GetResourceById<Model>(GOptr->GetComponent<Mesh>()->meshID);
 	if (m->isAnimated()) {
 		return m->getBlendOnTransition();

--- a/TheOneScripting/AbilityAdrenalineRush.cs
+++ b/TheOneScripting/AbilityAdrenalineRush.cs
@@ -5,13 +5,13 @@ public class AbilityAdrenalineRush : Ability
     IGameObject playerGO;
     PlayerScript player;
 
-    float healAmount = 0.3f; // in %
-    float speedAmount = 0.5f; // in %
-    float damageAmount = 0.5f; // in %
+    readonly float healAmount = 0.3f; // in %
+    readonly float speedAmount = 0.5f; // in %
+    readonly float damageAmount = 0.5f; // in %
 
-    float healthRegenTime = 3.0f;
+    readonly float healthRegenTime = 3.0f;
     float healthRegenTimeCounter = 3.0f;
-    float intervalTime = 0.2f;
+    readonly float intervalTime = 0.2f;
     float timeSinceLastTick = 0.0f;
     float healingInterval = 0.0f;
 
@@ -98,7 +98,7 @@ public class AbilityAdrenalineRush : Ability
 
             activeTimeCounter = activeTime;
             state = AbilityState.COOLDOWN;
-            
+
             Debug.Log("Ability AdrenalineRush on Cooldown");
         }
 

--- a/TheOneScripting/AbilityDash.cs
+++ b/TheOneScripting/AbilityDash.cs
@@ -5,12 +5,9 @@ public class AbilityDash : Ability
     IGameObject playerGO;
     PlayerScript player;
 
-    float dashSpeed = 50.0f;
-    float rollPotency = 2.0f;
-    float dashPotency = 3.0f;
+    readonly float rollPotency = 2.0f;
+    readonly float dashPotency = 3.0f;
 
-    Vector3 moveDir = Vector3.zero;
-    
     public override void Start()
     {
         abilityName = "Roll";
@@ -55,7 +52,7 @@ public class AbilityDash : Ability
 
         state = AbilityState.ACTIVE;
 
-        if(player.dashAbilityName == "Roll")
+        if (player.dashAbilityName == "Roll")
         {
             attachedGameObject.source.Play(IAudioSource.AudioEvent.P_ROLL);
         }
@@ -73,7 +70,7 @@ public class AbilityDash : Ability
         {
             // update time
             activeTimeCounter -= Time.deltaTime;
-            if(player.dashAbilityName == "Roll")
+            if (player.dashAbilityName == "Roll")
             {
                 player.attachedGameObject.transform.Translate(player.lastMovementDirection * rollPotency * player.baseSpeed * Time.deltaTime);
             }

--- a/TheOneScripting/AbilityFlamethrower.cs
+++ b/TheOneScripting/AbilityFlamethrower.cs
@@ -2,16 +2,11 @@
 
 public class AbilityFlamethrower : Ability
 {
-    IGameObject playerGO;
-    PlayerScript player;
 
-    //Weapon Flamethrower;
 
     public override void Start()
     {
         name = "Flamethrower";
-        playerGO = IGameObject.Find("SK_MainCharacter");
-        player = playerGO.GetComponent<PlayerScript>();
 
         activeTime = 10.0f;
         cooldownTime = 20.0f;

--- a/TheOneScripting/AbilityGrenadeLauncher.cs
+++ b/TheOneScripting/AbilityGrenadeLauncher.cs
@@ -5,11 +5,11 @@ public class AbilityGrenadeLauncher : Ability
     IGameObject playerGO;
     PlayerScript player;
 
-    float range = 200.0f;
-    float explosionRadius = 40f;
+    readonly float range = 200.0f;
+    readonly float explosionRadius = 40f;
     Vector3 explosionCenterPos = Vector3.zero;
 
-    float grenadeVelocity = 250f;
+    readonly float grenadeVelocity = 250f;
 
     public override void Start()
     {
@@ -60,24 +60,24 @@ public class AbilityGrenadeLauncher : Ability
 
     public override void WhileActive()
     {
-        explosionCenterPos = player.attachedGameObject.transform.position + player.lastMovementDirection * range;
+        explosionCenterPos = player.attachedGameObject.transform.Position + player.lastMovementDirection * range;
 
-        if(activeTimeCounter > 0)
+        if (activeTimeCounter > 0)
         {
             activeTimeCounter -= Time.deltaTime;
         }
         else if (Input.GetKeyboardButton(Input.KeyboardCode.FIVE) && activeTimeCounter <= 0)
         {
             Vector3 height = new Vector3(0.0f, 30.0f, 0.0f);
-            InternalCalls.InstantiateGrenade(player.attachedGameObject.transform.position + attachedGameObject.transform.forward * 13.5f + height, attachedGameObject.transform.rotation);
+            InternalCalls.InstantiateGrenade(player.attachedGameObject.transform.Position + attachedGameObject.transform.Forward * 13.5f + height, attachedGameObject.transform.Rotation);
             player.grenadeInitialVelocity = player.lastMovementDirection * grenadeVelocity;
 
             activeTimeCounter = activeTime;
             state = AbilityState.COOLDOWN;
         }
-        
 
-        Debug.DrawWireCircle(player.attachedGameObject.transform.position + Vector3.up * 4, range, new Vector3(0.0f, 0.3f, 1.0f));
+
+        Debug.DrawWireCircle(player.attachedGameObject.transform.Position + Vector3.up * 4, range, new Vector3(0.0f, 0.3f, 1.0f));
         Debug.DrawWireCircle(explosionCenterPos + Vector3.up * 4, explosionRadius, new Vector3(1.0f, 0.4f, 0.0f));
     }
 

--- a/TheOneScripting/AbilityHeal.cs
+++ b/TheOneScripting/AbilityHeal.cs
@@ -5,11 +5,9 @@ public class AbilityHeal : Ability
     IGameObject playerGO;
     PlayerScript player;
 
-    int numHeals = 0;
-    int maxHeals = 3;
-
-    float healAmount = 0.6f; // in %
-    float slowAmount = 0.4f; // in %
+    readonly int numHeals = 0;
+    readonly float healAmount = 0.6f; // in %
+    readonly float slowAmount = 0.4f; // in %
 
     float totalHeal = 0.0f;
 
@@ -55,7 +53,7 @@ public class AbilityHeal : Ability
     {
         // Calculate heal amount
 
-        if(player.healAbilityName == "Bandage")
+        if (player.healAbilityName == "Bandage")
         {
             totalHeal = player.maxLife * healAmount;
         }
@@ -63,8 +61,8 @@ public class AbilityHeal : Ability
         {
             totalHeal = player.maxLife * healAmount;
         }
-            totalHeal += player.life;
-        
+        totalHeal += player.life;
+
         float speedReduce = player.baseSpeed * slowAmount;
         player.speed -= speedReduce;
 
@@ -101,7 +99,7 @@ public class AbilityHeal : Ability
 
     public override void OnCooldown()
     {
-        if(cooldownTimeCounter > 0)
+        if (cooldownTimeCounter > 0)
         {
             // update time
             cooldownTimeCounter -= Time.deltaTime;
@@ -114,4 +112,4 @@ public class AbilityHeal : Ability
             Debug.Log("Ability Heal Ready");
         }
     }
-} 
+}

--- a/TheOneScripting/AbilityImpaciente.cs
+++ b/TheOneScripting/AbilityImpaciente.cs
@@ -9,11 +9,11 @@ public class AbilityImpaciente : Ability
     IGameObject playerGO;
     PlayerScript player;
 
-    int damage = 10;
+    readonly int damage = 10;
 
-    float slowAmount = 0.25f;
-    float impacienteShootingCd = 0.12f;
-    float knockbackPotency = -3f;
+    readonly float slowAmount = 0.25f;
+    readonly float impacienteShootingCd = 0.12f;
+    readonly float knockbackPotency = -3f;
 
     public override void Start()
     {
@@ -80,7 +80,7 @@ public class AbilityImpaciente : Ability
             // update time
             activeTimeCounter -= Time.deltaTime;
 
-            if(player.isShooting)
+            if (player.isShooting)
                 player.attachedGameObject.transform.Translate(player.lastMovementDirection * knockbackPotency * Time.deltaTime);
 
             Debug.LogWarning("Impaciente Bullets --> " + player.impacienteBulletCounter);

--- a/TheOneScripting/AbilityShield.cs
+++ b/TheOneScripting/AbilityShield.cs
@@ -5,9 +5,6 @@ public class AbilityShield : Ability
     IGameObject playerGO;
     PlayerScript player;
 
-    int killsToUnlock = 2;
-
-
     public override void Start()
     {
         abilityName = "Shield";
@@ -21,7 +18,7 @@ public class AbilityShield : Ability
         cooldownTime = 3.0f;
         cooldownTimeCounter = cooldownTime;
     }
-        
+
     public override void Update()
     {
         switch (state)
@@ -51,7 +48,7 @@ public class AbilityShield : Ability
 
     public override void ChargeAbility()
     {
-        if(player.shieldKillCounter == 2) 
+        if (player.shieldKillCounter == 2)
         {
             player.shieldKillCounter = 0;
             state = AbilityState.READY;

--- a/TheOneScripting/AdultXenomorphBehaviour.cs
+++ b/TheOneScripting/AdultXenomorphBehaviour.cs
@@ -61,13 +61,13 @@ public class AdultXenomorphBehaviour : MonoBehaviour
     {
         playerGO = IGameObject.Find("SK_MainCharacter");
         player = playerGO.GetComponent<PlayerScript>();
-        initialPos = attachedGameObject.transform.position;
+        initialPos = attachedGameObject.transform.Position;
 
         gameManager = IGameObject.Find("GameManager").GetComponent<GameManager>();
 
         attachedGameObject.animator.Play("Walk");
-        attachedGameObject.animator.blend = false;
-        attachedGameObject.animator.transitionTime = 0.0f;
+        attachedGameObject.animator.Blend = false;
+        attachedGameObject.animator.TransitionTime = 0.0f;
 
         acidSpitPSGO = attachedGameObject.FindInChildren("AcidSpitPS");
         tailAttackPSGO = attachedGameObject.FindInChildren("TailAttackPS");
@@ -85,8 +85,8 @@ public class AdultXenomorphBehaviour : MonoBehaviour
             DebugDraw();
 
             //Set the director vector and distance to the player
-            directorVector = (playerGO.transform.position - attachedGameObject.transform.position).Normalize();
-            playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+            directorVector = (playerGO.transform.Position - attachedGameObject.transform.Position).Normalize();
+            playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
 
             UpdateFSM();
             DoStateBehaviour();
@@ -105,7 +105,7 @@ public class AdultXenomorphBehaviour : MonoBehaviour
 
         if (detected)
         {
-            attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+            attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
             if (playerDistance < isCloseRange && !isClose)
             {
                 isClose = true;
@@ -165,7 +165,7 @@ public class AdultXenomorphBehaviour : MonoBehaviour
                 break;
             case States.Chase:
                 player.isFighting = true;
-                attachedGameObject.transform.Translate(attachedGameObject.transform.forward * movementSpeed * Time.deltaTime);
+                attachedGameObject.transform.Translate(attachedGameObject.transform.Forward * movementSpeed * Time.deltaTime);
                 break;
             case States.Patrol:
                 Patrol();
@@ -204,7 +204,7 @@ public class AdultXenomorphBehaviour : MonoBehaviour
 
     private void AcidSpit()
     {
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             ResetState();
         }
@@ -212,7 +212,7 @@ public class AdultXenomorphBehaviour : MonoBehaviour
 
     private void TailAttack()
     {
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             ResetState();
         }
@@ -261,9 +261,9 @@ public class AdultXenomorphBehaviour : MonoBehaviour
     private bool MoveTo(Vector3 targetPosition)
     {
         //Return true if arrived at destination
-        if (Vector3.Distance(attachedGameObject.transform.position, targetPosition) < 0.5f) return true;
+        if (Vector3.Distance(attachedGameObject.transform.Position, targetPosition) < 0.5f) return true;
 
-        Vector3 dirVector = (targetPosition - attachedGameObject.transform.position).Normalize();
+        Vector3 dirVector = (targetPosition - attachedGameObject.transform.Position).Normalize();
         attachedGameObject.transform.Translate(dirVector * movementSpeed * Time.deltaTime);
         //attachedGameObject.source.PlayAudio(AudioManager.EventIDs.E_REBEL_STEP);
         return false;
@@ -276,12 +276,12 @@ public class AdultXenomorphBehaviour : MonoBehaviour
         {
             if (!detected)
             {
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, detectedRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, detectedRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
             }
             else
             {
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, isCloseRange, new Vector3(1.0f, 0.0f, 0.0f)); //Red
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, maxChasingRange, new Vector3(1.0f, 0.0f, 1.0f)); //Purple
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, isCloseRange, new Vector3(1.0f, 0.0f, 0.0f)); //Red
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, maxChasingRange, new Vector3(1.0f, 0.0f, 1.0f)); //Purple
             }
         }
     }

--- a/TheOneScripting/AlienQueenBehaviour.cs
+++ b/TheOneScripting/AlienQueenBehaviour.cs
@@ -94,8 +94,8 @@ public class AlienQueenBehaviour : MonoBehaviour
             if (gameManager.colliderRender) { DebugDraw(); }
 
             //Set the director vector and distance to the player
-            directorVector = (playerGO.transform.position - attachedGameObject.transform.position).Normalize();
-            playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+            directorVector = (playerGO.transform.Position - attachedGameObject.transform.Position).Normalize();
+            playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
 
             UpdateFSM();
             DoStateBehaviour();
@@ -104,10 +104,12 @@ public class AlienQueenBehaviour : MonoBehaviour
 
     void UpdateFSM()
     {
-        if (life <= 0) { 
+        if (life <= 0)
+        {
             currentState = States.Dead;
             //attachedGameObject.source.PlayAudio(IAudioSource.EventIDs.E_QUEEN_DEATH);
-            return; }
+            return;
+        }
 
         if (playerDistance < farRangeThreshold && !isClose)
         {
@@ -151,7 +153,7 @@ public class AlienQueenBehaviour : MonoBehaviour
                 }
                 else
                 {
-                    attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+                    attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
                 }
                 return;
             case States.Attack:
@@ -254,9 +256,9 @@ public class AlienQueenBehaviour : MonoBehaviour
     private bool MoveTo(Vector3 targetPosition)
     {
 
-        if (Vector3.Distance(attachedGameObject.transform.position, targetPosition) < 0.5f) return true;
+        if (Vector3.Distance(attachedGameObject.transform.Position, targetPosition) < 0.5f) return true;
 
-        Vector3 dirVector = (targetPosition - attachedGameObject.transform.position).Normalize();
+        Vector3 dirVector = (targetPosition - attachedGameObject.transform.Position).Normalize();
         attachedGameObject.transform.Translate(dirVector * dashSpeed * Time.deltaTime);
 
         return false;
@@ -267,7 +269,7 @@ public class AlienQueenBehaviour : MonoBehaviour
         Debug.Log("HeadCharge() init");
         if (coordinatesToDash == Vector3.zero)
         {
-            coordinatesToDash = playerGO.transform.position;
+            coordinatesToDash = playerGO.transform.Position;
         }
         if (MoveTo(coordinatesToDash))
         {
@@ -318,13 +320,13 @@ public class AlienQueenBehaviour : MonoBehaviour
     private void XenoSpawn()
     {
 
-        Vector3 scale = new Vector3(1,1,1);
-        
+        Vector3 scale = new Vector3(1, 1, 1);
+
         //InternalCalls.InstantiateXenomorph(attachedGameObject.transform.position + attachedGameObject.transform.forward * (attachedGameObject.GetComponent<ICollider2D>().radius + 12.5f),
         //                                   attachedGameObject.transform.rotation,
         //                                   scale);
         InternalCalls.CreatePrefab("SK_Facehugger",
-            attachedGameObject.transform.position + attachedGameObject.transform.forward*(attachedGameObject.GetComponent<ICollider2D>().radius + 12.5f));
+            attachedGameObject.transform.Position + attachedGameObject.transform.Forward * (attachedGameObject.GetComponent<ICollider2D>().radius + 12.5f));
         attachedGameObject.source.Play(IAudioSource.AudioEvent.E_X_ADULT_SPAWN);
         ResetState();
     }
@@ -340,7 +342,7 @@ public class AlienQueenBehaviour : MonoBehaviour
     private void GiantJump(bool isJumpingForward)
     {
         float directionMultiplier = isJumpingForward ? -1.0f : 1.0f;
-        attachedGameObject.transform.Translate(attachedGameObject.transform.forward * directionMultiplier * jumpSpeed * Time.deltaTime);
+        attachedGameObject.transform.Translate(attachedGameObject.transform.Forward * directionMultiplier * jumpSpeed * Time.deltaTime);
 
         if (up)
         {
@@ -373,9 +375,9 @@ public class AlienQueenBehaviour : MonoBehaviour
         {
             ResetState();
 
-            attachedGameObject.transform.position = new Vector3(attachedGameObject.transform.position.x,
+            attachedGameObject.transform.Position = new Vector3(attachedGameObject.transform.Position.x,
                                                                 0.0f,
-                                                                attachedGameObject.transform.position.z);
+                                                                attachedGameObject.transform.Position.z);
             currentHeight = 0.0f;
             up = true;
         }
@@ -390,6 +392,6 @@ public class AlienQueenBehaviour : MonoBehaviour
 
     private void DebugDraw()
     {
-        Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, farRangeThreshold, new Vector3(1.0f, 0.0f, 1.0f)); //Purpul jiji
+        Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, farRangeThreshold, new Vector3(1.0f, 0.0f, 1.0f)); //Purpul jiji
     }
 }

--- a/TheOneScripting/AlienQueenBehaviourNew.cs
+++ b/TheOneScripting/AlienQueenBehaviourNew.cs
@@ -34,7 +34,7 @@ public class AlienQueenBehaviourNew : MonoBehaviour
 
         DoStateBehaviour();
 
-        if (currentLife < 0) { isDead = true; attachedGameObject.animator.Play("Death"); } 
+        if (currentLife < 0) { isDead = true; attachedGameObject.animator.Play("Death"); }
     }
 
     #region FSM
@@ -58,7 +58,7 @@ public class AlienQueenBehaviourNew : MonoBehaviour
     bool CheckPhaseChange()
     {
         if (currentPhase < 2 && currentLife <= maxLife / 1.5f ||
-            currentPhase < 3 && currentLife <= maxLife / 3.0f) 
+            currentPhase < 3 && currentLife <= maxLife / 3.0f)
         {
             Debug.LogWarning("Phase changing from " + currentPhase.ToString() + " to " + (currentPhase + 1).ToString());
             currentState = States.ChangingPhase;
@@ -90,7 +90,7 @@ public class AlienQueenBehaviourNew : MonoBehaviour
                 DoPhaseChange();
                 break;
             default:
-                attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+                attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
                 Debug.LogError("Fallen out of FSM");
                 break;
         }
@@ -100,13 +100,13 @@ public class AlienQueenBehaviourNew : MonoBehaviour
     float playerDistance; //Do not touch
     void DoIdle()
     {
-        playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+        playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
         if (playerDistance < detectionRange)
         {
             currentState = States.Zigzag;
         }
 
-        Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up, detectionRange, Color.asianYellow.ToVector3());
+        Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up, detectionRange, Color.asianYellow.ToVector3());
     }
 
     float alienSpeed = 300;
@@ -137,11 +137,11 @@ public class AlienQueenBehaviourNew : MonoBehaviour
 
             attachedGameObject.animator.Play("Run");
 
-            lastPlayerPos = playerGO.transform.position;
+            lastPlayerPos = playerGO.transform.Position;
             attachedGameObject.transform.LookAt2D(lastPlayerPos);
-            chargeDirectionRightVec = attachedGameObject.transform.right;
-            chargeDirectionForwardVec = attachedGameObject.transform.forward;
-            yProgress = attachedGameObject.transform.position;
+            chargeDirectionRightVec = attachedGameObject.transform.Right;
+            chargeDirectionForwardVec = attachedGameObject.transform.Forward;
+            yProgress = attachedGameObject.transform.Position;
             zigzagPos = 270.0f;
             reachedPoint = false;
         }
@@ -157,7 +157,7 @@ public class AlienQueenBehaviourNew : MonoBehaviour
         moveToTarget = xProgress + yProgress;
 
         attachedGameObject.transform.LookAt2D(moveToTarget);
-        attachedGameObject.transform.Translate(attachedGameObject.transform.forward * alienSpeed * Time.deltaTime);
+        attachedGameObject.transform.Translate(attachedGameObject.transform.Forward * alienSpeed * Time.deltaTime);
 
         //Debug.DrawWireSphere(xProgress, 10.0f, Color.russianRed.ToVector3());
         //Debug.DrawWireSphere(yProgress, 10.0f, Color.scrumMasterBlue.ToVector3());
@@ -197,20 +197,20 @@ public class AlienQueenBehaviourNew : MonoBehaviour
 
         //Moving towards the player until reaching circle size
         if (!circleStarted &&
-            Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position) > circleSize + circleSize / 2)
+            Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position) > circleSize + circleSize / 2)
         {
-            MoveTo(playerGO.transform.position, alienCircleSpeed / 1.5f);
-            attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+            MoveTo(playerGO.transform.Position, alienCircleSpeed / 1.5f);
+            attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
 
             //Debug.DrawWireCircle(playerGO.transform.position, circleSize, Color.pitufoBlue.ToVector3());
 
             return;
         }
-        else 
-        { 
+        else
+        {
             circleStarted = true;
 
-            Vector3 directorVec = playerGO.transform.position - attachedGameObject.transform.position;
+            Vector3 directorVec = playerGO.transform.Position - attachedGameObject.transform.Position;
             counterPos = (float)Math.Atan2(directorVec.z, directorVec.x) * 180.0f / (float)Math.PI + 180.0f;
 
             if (counterPos < 0) { counterPos += 360.0f; }
@@ -223,12 +223,12 @@ public class AlienQueenBehaviourNew : MonoBehaviour
         progressPos = Vector3.zero;
         progressPos += Vector3.right * (float)Math.Cos(-counterPos * Math.PI / 180.0f) * circleSize;
         progressPos += Vector3.forward * (float)Math.Sin(counterPos * Math.PI / 180.0f) * circleSize;
-        progressPos += playerGO.transform.position;
+        progressPos += playerGO.transform.Position;
 
         //Debug.DrawWireSphere(progressPos, 10.0f, Color.chernobylGreen.ToVector3());
 
         attachedGameObject.transform.LookAt2D(progressPos);
-        attachedGameObject.transform.Translate(attachedGameObject.transform.forward * alienCircleSpeed * Time.deltaTime);
+        attachedGameObject.transform.Translate(attachedGameObject.transform.Forward * alienCircleSpeed * Time.deltaTime);
 
         countDown += Time.deltaTime;
         if (countDown > circleTime)
@@ -251,7 +251,7 @@ public class AlienQueenBehaviourNew : MonoBehaviour
             countDown = 0.0f;
         }
 
-        attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+        attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
 
         countDown += Time.deltaTime;
         if (countDown > waitingTime)
@@ -374,7 +374,7 @@ public class AlienQueenBehaviourNew : MonoBehaviour
             attachedGameObject.animator.Play("Facehugger_Spawn");
         }
 
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             currentPhase++;
             currentState = States.Attack;
@@ -441,11 +441,11 @@ public class AlienQueenBehaviourNew : MonoBehaviour
             case 3:
                 switch (stagePhase3)
                 {
-                    case 0:     return Attacks.AcidPhase2;
-                    case 1:     return Attacks.Jump;
-                    case 2:     return Attacks.TailPhase2;
-                    case 3:     return Attacks.Charge;
-                    case 4:     return Attacks.Spawn;
+                    case 0: return Attacks.AcidPhase2;
+                    case 1: return Attacks.Jump;
+                    case 2: return Attacks.TailPhase2;
+                    case 3: return Attacks.Charge;
+                    case 4: return Attacks.Spawn;
                     default:
                         Debug.LogError("Queen FSM fell into unintended behaviour when choosing attack (phase 3)");
                         return Attacks.None;
@@ -465,7 +465,7 @@ public class AlienQueenBehaviourNew : MonoBehaviour
             attackFirstFrame = false;
         }
 
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             if (currentPhase == 1)
             {
@@ -489,14 +489,14 @@ public class AlienQueenBehaviourNew : MonoBehaviour
             attackFirstFrame = false;
         }
 
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             combinedFirstAttack = true;
             attackedFinished = true;
         }
     }
 
-    
+
     private bool AcidBomb()
     {
         if (attackFirstFrame)
@@ -505,7 +505,7 @@ public class AlienQueenBehaviourNew : MonoBehaviour
             attackFirstFrame = false;
         }
 
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             if (currentPhase == 1)
             {
@@ -532,7 +532,7 @@ public class AlienQueenBehaviourNew : MonoBehaviour
             attackFirstFrame = false;
         }
 
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             combinedFirstAttack = true;
             attackedFinished = true;
@@ -576,14 +576,14 @@ public class AlienQueenBehaviourNew : MonoBehaviour
 
             Vector3 scale = new Vector3(1, 1, 1);
 
-            InternalCalls.InstantiateXenomorph(attachedGameObject.transform.position +
-                                               attachedGameObject.transform.forward *
+            InternalCalls.InstantiateXenomorph(attachedGameObject.transform.Position +
+                                               attachedGameObject.transform.Forward *
                                                (attachedGameObject.GetComponent<ICollider2D>().radius + 12.5f),
-                                               attachedGameObject.transform.rotation,
+                                               attachedGameObject.transform.Rotation,
                                                scale);
         }
 
-        attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+        attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
 
         countDown += Time.deltaTime;
         if (countDown >= spawnDuration)
@@ -619,22 +619,22 @@ public class AlienQueenBehaviourNew : MonoBehaviour
             if (posCalc)
             {
                 posCalc = false;
-                attachedGameObject.transform.position = new Vector3(playerGO.transform.position.x,
-                                                                    attachedGameObject.transform.position.y,
-                                                                    playerGO.transform.position.z);
+                attachedGameObject.transform.Position = new Vector3(playerGO.transform.Position.x,
+                                                                    attachedGameObject.transform.Position.y,
+                                                                    playerGO.transform.Position.z);
             }
         }
         else if (stopCountDown > 0.9f) { onAir = true; }
 
         if (onAir) { attachedGameObject.GetComponent<ICollider2D>().radius = 0.0f; }
-        else       { attachedGameObject.GetComponent<ICollider2D>().radius = 35.0f; }
+        else { attachedGameObject.GetComponent<ICollider2D>().radius = 35.0f; }
 
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
-            if (jumpNum >= 2) 
-            { 
-                attackedFinished = true; 
-                attachedGameObject.transform.LookAt2D(playerGO.transform.position); 
+            if (jumpNum >= 2)
+            {
+                attackedFinished = true;
+                attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
             }
             else
             {
@@ -658,19 +658,19 @@ public class AlienQueenBehaviourNew : MonoBehaviour
 
             countDown = 0;
             stopCountDown = 0;
-            attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+            attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
         }
 
         stopCountDown += Time.deltaTime;
         if (stopCountDown > 1.05f && stopCountDown < 3.15f)
         {
-            attachedGameObject.transform.Translate(attachedGameObject.transform.forward * chargeSpeed * Time.deltaTime);
+            attachedGameObject.transform.Translate(attachedGameObject.transform.Forward * chargeSpeed * Time.deltaTime);
         }
 
         countDown += Time.deltaTime;
         if (countDown >= headChargeDuration)
         {
-            attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+            attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
             attackedFinished = true;
         }
     }
@@ -680,9 +680,9 @@ public class AlienQueenBehaviourNew : MonoBehaviour
     bool MoveTo(Vector3 targetPosition, float speed)
     {
         //Return true if arrived at destination
-        if (Vector3.Distance(attachedGameObject.transform.position, targetPosition) < 0.5f) return true;
+        if (Vector3.Distance(attachedGameObject.transform.Position, targetPosition) < 0.5f) return true;
 
-        Vector3 dirVector = (targetPosition - attachedGameObject.transform.position).Normalize();
+        Vector3 dirVector = (targetPosition - attachedGameObject.transform.Position).Normalize();
         attachedGameObject.transform.Translate(dirVector * speed * Time.deltaTime);
         return false;
     }

--- a/TheOneScripting/AnarchistBehaviour.cs
+++ b/TheOneScripting/AnarchistBehaviour.cs
@@ -23,26 +23,19 @@ class AnarchistBehaviour : MonoBehaviour
     Vector3 initialPos;
 
     float life = 100;
-    ICollider2D collider;
     PlayerScript player;
     GameManager gameManager;
-
-    IGameObject iShotPSGO;
 
     public override void Start()
     {
         playerGO = IGameObject.Find("SK_MainCharacter");
         player = playerGO.GetComponent<PlayerScript>();
-        initialPos = attachedGameObject.transform.position;
-
-        collider = attachedGameObject.GetComponent<ICollider2D>();
+        initialPos = attachedGameObject.transform.Position;
 
         gameManager = IGameObject.Find("GameManager").GetComponent<GameManager>();
         attachedGameObject.animator.Play("Scan");
 
-        attachedGameObject.animator.blend = false;
-
-        iShotPSGO = attachedGameObject.FindInChildren("ShotPS");
+        attachedGameObject.animator.Blend = false;
     }
 
     public override void Update()
@@ -51,7 +44,7 @@ class AnarchistBehaviour : MonoBehaviour
 
         if (currentState == States.Dying)
         {
-            if (attachedGameObject.animator.currentAnimHasFinished)
+            if (attachedGameObject.animator.CurrentAnimHasFinished)
             {
                 currentState = States.Dead;
                 return;
@@ -68,7 +61,7 @@ class AnarchistBehaviour : MonoBehaviour
             return;
         }
 
-        playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+        playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
 
         UpdateFSMStates();
         DoStateBehaviour();
@@ -141,7 +134,7 @@ class AnarchistBehaviour : MonoBehaviour
             goingToRoundPos = !MoveTo(roundPos);
         }
 
-        if (gameManager.colliderRender) { Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 3, rangeToInspect, Vector3.right + Vector3.up); }
+        if (gameManager.colliderRender) { Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 3, rangeToInspect, Vector3.right + Vector3.up); }
     }
 
     enum InspctStates
@@ -162,7 +155,7 @@ class AnarchistBehaviour : MonoBehaviour
         {
             Debug.Log("StartingState");
             lastState = currentState;
-            playerLastPosition = playerGO.transform.position;
+            playerLastPosition = playerGO.transform.Position;
         }
 
         switch (currentSubstate)
@@ -174,7 +167,7 @@ class AnarchistBehaviour : MonoBehaviour
                     currentSubstate = InspctStates.Inspecting;
                 }
                 attachedGameObject.transform.LookAt2D(playerLastPosition);
-                if (gameManager.colliderRender) { Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 3, inspectDetectionRadius, Vector3.right + Vector3.up * 0.3f); }
+                if (gameManager.colliderRender) { Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 3, inspectDetectionRadius, Vector3.right + Vector3.up * 0.3f); }
                 break;
             case InspctStates.Inspecting:
                 attachedGameObject.animator.Play("Scan");
@@ -185,7 +178,7 @@ class AnarchistBehaviour : MonoBehaviour
                     currentSubstate = InspctStates.ComingBack;
                 }
                 attachedGameObject.transform.Rotate(Vector3.up * 150.0f * Time.deltaTime);
-                if (gameManager.colliderRender) { Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 3, inspectDetectionRadius, Vector3.right + Vector3.up * 0.5f); }
+                if (gameManager.colliderRender) { Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 3, inspectDetectionRadius, Vector3.right + Vector3.up * 0.5f); }
                 break;
             case InspctStates.ComingBack:
                 attachedGameObject.animator.Play("Walk");
@@ -195,14 +188,14 @@ class AnarchistBehaviour : MonoBehaviour
                     currentState = States.Patrol;
                 }
                 attachedGameObject.transform.LookAt2D(initialPos);
-                if (gameManager.colliderRender) { Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 3, inspectDetectionRadius, Vector3.right + Vector3.up * 0.8f); }
+                if (gameManager.colliderRender) { Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 3, inspectDetectionRadius, Vector3.right + Vector3.up * 0.8f); }
                 break;
             default:
                 break;
         }
 
-        Vector3 directorVec = (attachedGameObject.transform.position - playerGO.transform.position).Normalize();
-        float dot = Vector3.Dot(attachedGameObject.transform.forward, directorVec);
+        Vector3 directorVec = (attachedGameObject.transform.Position - playerGO.transform.Position).Normalize();
+        float dot = Vector3.Dot(attachedGameObject.transform.Forward, directorVec);
 
         if (playerDistance < inspectDetectionRadius && dot > 0.7f)
         {
@@ -220,7 +213,7 @@ class AnarchistBehaviour : MonoBehaviour
 
     void AttackState()
     {
-        attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+        attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
 
         if (playerDistance > loseRange)
         {
@@ -256,7 +249,7 @@ class AnarchistBehaviour : MonoBehaviour
             }
         }
 
-        if (gameManager.colliderRender) { Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 3, loseRange, Vector3.right); }
+        if (gameManager.colliderRender) { Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 3, loseRange, Vector3.right); }
     }
 
     readonly float movementSpeed = 50.0f;
@@ -264,9 +257,9 @@ class AnarchistBehaviour : MonoBehaviour
     bool MoveTo(Vector3 targetPosition)
     {
         //Return true if arrived at destination
-        if (Vector3.Distance(attachedGameObject.transform.position, targetPosition) < 0.5f) return true;
+        if (Vector3.Distance(attachedGameObject.transform.Position, targetPosition) < 0.5f) return true;
 
-        Vector3 dirVector = (targetPosition - attachedGameObject.transform.position).Normalize();
+        Vector3 dirVector = (targetPosition - attachedGameObject.transform.Position).Normalize();
         attachedGameObject.transform.Translate(dirVector * movementSpeed * Time.deltaTime);
         return false;
     }

--- a/TheOneScripting/Bullet.cs
+++ b/TheOneScripting/Bullet.cs
@@ -21,6 +21,6 @@ class Bullet : MonoBehaviour
             return;
         }
 
-        attachedGameObject.transform.Translate(attachedGameObject.transform.forward * bulletSpeed * Time.deltaTime);
+        attachedGameObject.transform.Translate(attachedGameObject.transform.Forward * bulletSpeed * Time.deltaTime);
     }
 }

--- a/TheOneScripting/CamControlTest.cs
+++ b/TheOneScripting/CamControlTest.cs
@@ -1,26 +1,31 @@
 ﻿public class CamControlTest : MonoBehaviour
 {
 
-	float speed = 0.2f;
+    float speed = 0.2f;
     public override void Update()
     {
-        if (Input.GetKeyboardButton(Input.KeyboardCode.UP)) {
+        if (Input.GetKeyboardButton(Input.KeyboardCode.UP))
+        {
             attachedGameObject.transform.Translate(Vector3.forward * speed);
         }
 
-        if (Input.GetKeyboardButton(Input.KeyboardCode.RIGHT)) {
+        if (Input.GetKeyboardButton(Input.KeyboardCode.RIGHT))
+        {
             attachedGameObject.transform.Translate(Vector3.right * -speed);
         }
 
-        if (Input.GetKeyboardButton(Input.KeyboardCode.DOWN)) {
+        if (Input.GetKeyboardButton(Input.KeyboardCode.DOWN))
+        {
             attachedGameObject.transform.Translate(Vector3.forward * -speed);
         }
 
-        if (Input.GetKeyboardButton(Input.KeyboardCode.LEFT)) {
+        if (Input.GetKeyboardButton(Input.KeyboardCode.LEFT))
+        {
             attachedGameObject.transform.Translate(Vector3.right * speed);
         }
 
-        if (Input.GetKeyboardButton(Input.KeyboardCode.W)) {
+        if (Input.GetKeyboardButton(Input.KeyboardCode.W))
+        {
             attachedGameObject.transform.Translate(Vector3.up * speed);
         }
     }

--- a/TheOneScripting/CameraMovement.cs
+++ b/TheOneScripting/CameraMovement.cs
@@ -2,23 +2,23 @@
 
 public class CameraMovement : MonoBehaviour
 {
-	IGameObject playerGO;
+    IGameObject playerGO;
     PlayerScript playerScript;
-	Vector3 camOffset = new Vector3(90, 220, 90);
-	//float camJoyDisplacement = 10.0f;
+    readonly Vector3 camOffset = new Vector3(90, 220, 90);
+    //float camJoyDisplacement = 10.0f;
 
-    float cameraMargin = 15.0f;
+    readonly float cameraMargin = 15.0f;
 
-	public override void Start()
-	{
-		playerGO = IGameObject.Find("SK_MainCharacter");
+    public override void Start()
+    {
+        playerGO = IGameObject.Find("SK_MainCharacter");
         playerScript = playerGO.GetComponent<PlayerScript>();
-        attachedGameObject.transform.position = playerGO.transform.position + camOffset;
-        attachedGameObject.transform.CamLookAt(playerGO.transform.position);
+        attachedGameObject.transform.Position = playerGO.transform.Position + camOffset;
+        attachedGameObject.transform.CamLookAt(playerGO.transform.Position);
     }
 
     public override void Update()
-	{
+    {
         if (!attachedGameObject.transform.ComponentCheck()) { return; }
 
         DoCameraMovement();
@@ -26,7 +26,7 @@ public class CameraMovement : MonoBehaviour
 
     void DoCameraMovement()
     {
-        Vector3 difference = attachedGameObject.transform.position - playerGO.transform.position;
+        Vector3 difference = attachedGameObject.transform.Position - playerGO.transform.Position;
 
         Vector3 displacement = difference - camOffset;
 

--- a/TheOneScripting/ChestbursterBehaviour.cs
+++ b/TheOneScripting/ChestbursterBehaviour.cs
@@ -59,8 +59,8 @@ public class ChestbursterBehaviour : MonoBehaviour
         gameManager = IGameObject.Find("GameManager").GetComponent<GameManager>();
 
         attachedGameObject.animator.Play("Move");
-        attachedGameObject.animator.blend = false;
-        attachedGameObject.animator.transitionTime = 0.0f;
+        attachedGameObject.animator.Blend = false;
+        attachedGameObject.animator.TransitionTime = 0.0f;
 
         tailPunchPSGO = attachedGameObject.FindInChildren("TailPunchPS");
         tailTripPSGO = attachedGameObject.FindInChildren("TailTripPS");
@@ -79,7 +79,7 @@ public class ChestbursterBehaviour : MonoBehaviour
 
             //Set the director vector and distance to the player
             //directorVector = (playerGO.transform.position - attachedGameObject.transform.position).Normalize();
-            playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+            playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
 
             UpdateFSM();
             DoStateBehaviour();
@@ -94,7 +94,7 @@ public class ChestbursterBehaviour : MonoBehaviour
 
         if (detected)
         {
-            attachedGameObject.transform.Translate(attachedGameObject.transform.forward * movementSpeed * Time.deltaTime);
+            attachedGameObject.transform.Translate(attachedGameObject.transform.Forward * movementSpeed * Time.deltaTime);
 
             if (playerDistance < farRangeThreshold && !isClose)
             {
@@ -135,12 +135,12 @@ public class ChestbursterBehaviour : MonoBehaviour
         {
             case States.Idle:
                 if (currentAttack == ChestbursterAttack.None && detected)
-                    attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+                    attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
 
                 break;
             case States.ChaseAttack:
                 player.isFighting = true;
-                attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+                attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
 
                 ChooseAttack();
 
@@ -191,7 +191,7 @@ public class ChestbursterBehaviour : MonoBehaviour
     {
         //Debug.Log("Attempt to do TailPunch");
 
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             ResetState();
         }
@@ -202,7 +202,7 @@ public class ChestbursterBehaviour : MonoBehaviour
     {
         //Debug.Log("Attempt to do TailTrip");
 
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             ResetState();
         }
@@ -230,12 +230,12 @@ public class ChestbursterBehaviour : MonoBehaviour
         {
             if (!detected)
             {
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, enemyDetectedRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, enemyDetectedRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
             }
             else
             {
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, maxChasingRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, farRangeThreshold, new Vector3(0.0f, 0.8f, 1.0f)); //Blue
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, maxChasingRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, farRangeThreshold, new Vector3(0.0f, 0.8f, 1.0f)); //Blue
             }
         }
     }

--- a/TheOneScripting/Event.cs
+++ b/TheOneScripting/Event.cs
@@ -16,7 +16,7 @@ public abstract class Event : MonoBehaviour
         OPENPOPUP,
         //Add events
     }
-    public EventType eventType {  get; set; }
+    public EventType eventType { get; set; }
 
     public abstract bool CheckEventIsPossible();
     public abstract bool DoEvent();

--- a/TheOneScripting/EventCheckpoint.cs
+++ b/TheOneScripting/EventCheckpoint.cs
@@ -10,20 +10,18 @@ using static UiManager;
 public class EventCheckpoint : Event
 {
     IGameObject playerGO;
-    PlayerScript player;
 
     GameManager gameManager;
     UiManager menuManager;
 
     float playerDistance;
 
-    float tpRange = 100.0f;
+    readonly float tpRange = 100.0f;
     bool inRange = false;
 
     public override void Start()
     {
         playerGO = IGameObject.Find("SK_MainCharacter");
-        player = playerGO.GetComponent<PlayerScript>();
 
         gameManager = IGameObject.Find("GameManager").GetComponent<GameManager>();
 
@@ -44,7 +42,7 @@ public class EventCheckpoint : Event
 
     public override bool CheckEventIsPossible()
     {
-        playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+        playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
 
         if (playerDistance < tpRange)
         {
@@ -75,11 +73,11 @@ public class EventCheckpoint : Event
     {
         if (!inRange)
         {
-            Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, tpRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
+            Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, tpRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
         }
         else
         {
-            Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, tpRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
+            Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, tpRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
         }
     }
 }

--- a/TheOneScripting/EventCollectible.cs
+++ b/TheOneScripting/EventCollectible.cs
@@ -10,12 +10,11 @@ public class EventCollectible : Event
     IGameObject itemManagerGO;
     ItemManager itemManager;
     UiManager uiManager;
-    Item currentItem;
     float playerDistance;
 
     GameManager gameManager;
 
-    float collectibleRange = 100.0f;
+    readonly float collectibleRange = 100.0f;
 
     //debug
     bool inRange = false;
@@ -30,7 +29,7 @@ public class EventCollectible : Event
         gameManager = IGameObject.Find("GameManager").GetComponent<GameManager>();
         uiManager = IGameObject.Find("UI_Manager").GetComponent<UiManager>();
     }
-    
+
     public override void Update()
     {
 
@@ -45,8 +44,8 @@ public class EventCollectible : Event
     public override bool CheckEventIsPossible()
     {
         //Set the distance to the player
-        playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
-        
+        playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
+
         if (playerDistance < collectibleRange)
         {
             inRange = true;
@@ -80,11 +79,11 @@ public class EventCollectible : Event
     {
         if (!inRange)
         {
-            Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, collectibleRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
+            Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, collectibleRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
         }
         else
         {
-            Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, collectibleRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
+            Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, collectibleRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
         }
     }
 }

--- a/TheOneScripting/EventNextRoom.cs
+++ b/TheOneScripting/EventNextRoom.cs
@@ -9,13 +9,12 @@ using System.Text.RegularExpressions;
 public class EventNextRoom : Event
 {
     IGameObject playerGO;
-    PlayerScript player;
 
     GameManager gameManager;
 
     float playerDistance;
 
-    float tpRange = 100.0f;
+    readonly float tpRange = 100.0f;
     bool inRange = false;
 
     string goName;
@@ -23,7 +22,6 @@ public class EventNextRoom : Event
     public override void Start()
     {
         playerGO = IGameObject.Find("SK_MainCharacter");
-        player = playerGO.GetComponent<PlayerScript>();
 
         gameManager = IGameObject.Find("GameManager").GetComponent<GameManager>();
 
@@ -43,7 +41,7 @@ public class EventNextRoom : Event
 
     public override bool CheckEventIsPossible()
     {
-        playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+        playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
 
         if (playerDistance < tpRange)
         {
@@ -61,7 +59,7 @@ public class EventNextRoom : Event
     {
         bool ret = true;
 
-        if(Input.GetControllerButton(Input.ControllerButtonCode.Y) || Input.GetKeyboardButton(Input.KeyboardCode.E))
+        if (Input.GetControllerButton(Input.ControllerButtonCode.Y) || Input.GetKeyboardButton(Input.KeyboardCode.E))
         {
             string sceneName = ExtractSceneName();
 
@@ -81,11 +79,11 @@ public class EventNextRoom : Event
     {
         if (!inRange)
         {
-            Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, tpRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
+            Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, tpRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
         }
         else
         {
-            Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, tpRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
+            Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, tpRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
         }
     }
 

--- a/TheOneScripting/EventOpenPopUp.cs
+++ b/TheOneScripting/EventOpenPopUp.cs
@@ -62,7 +62,7 @@ public class EventOpenPopUp : Event
 
     public override bool CheckEventIsPossible()
     {
-        playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+        playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
 
         if (playerDistance < tpRange)
         {
@@ -97,11 +97,11 @@ public class EventOpenPopUp : Event
     {
         if (!inRange)
         {
-            Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, tpRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
+            Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, tpRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
         }
         else
         {
-            Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, tpRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
+            Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, tpRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
         }
     }
 

--- a/TheOneScripting/EventTriggerDialog.cs
+++ b/TheOneScripting/EventTriggerDialog.cs
@@ -60,7 +60,7 @@ public class EventTriggerDialog : Event
 
     public override bool CheckEventIsPossible()
     {
-        playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+        playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
 
         if (playerDistance < tpRange)
         {
@@ -105,11 +105,11 @@ public class EventTriggerDialog : Event
     {
         if (!inRange)
         {
-            Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, tpRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
+            Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, tpRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
         }
         else
         {
-            Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, tpRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
+            Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, tpRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
         }
     }
 

--- a/TheOneScripting/ExampleScript.cs
+++ b/TheOneScripting/ExampleScript.cs
@@ -8,8 +8,8 @@ public class ExampleScript : MonoBehaviour
     public override void Update()
     {
         //Horizontal
-        if (attachedGameObject.transform.position.x > 5.0f) goingRight = false;
-        else if (attachedGameObject.transform.position.x < -5.0f) goingRight = true;
+        if (attachedGameObject.transform.Position.x > 5.0f) goingRight = false;
+        else if (attachedGameObject.transform.Position.x < -5.0f) goingRight = true;
 
         if (goingRight)
         {
@@ -21,8 +21,8 @@ public class ExampleScript : MonoBehaviour
         }
 
         //Vertical
-        if (attachedGameObject.transform.position.y > 5.0f) goingUp = false;
-        else if (attachedGameObject.transform.position.y < -5.0f) goingUp = true;
+        if (attachedGameObject.transform.Position.y > 5.0f) goingUp = false;
+        else if (attachedGameObject.transform.Position.y < -5.0f) goingUp = true;
 
         if (goingUp)
         {
@@ -34,4 +34,3 @@ public class ExampleScript : MonoBehaviour
         }
     }
 }
- 

--- a/TheOneScripting/FaceHuggerBehaviour.cs
+++ b/TheOneScripting/FaceHuggerBehaviour.cs
@@ -14,16 +14,16 @@ public class FaceHuggerBehaviour : MonoBehaviour
     Vector3 directorVector;
     float playerDistance;
 
-    float life = 50;
+    readonly float life = 50;
 
     float movementSpeed = 35.0f * 2;
 
     States currentState = States.Idle;
     bool detected = false;
 
-    float enemyDetectedRange = 180.0f;
-    float maxAttackRange = 90.0f;
-    float maxChasingRange = 180.0f;
+    readonly float enemyDetectedRange = 180.0f;
+    readonly float maxAttackRange = 90.0f;
+    readonly float maxChasingRange = 180.0f;
 
     bool isJumping = false;
 
@@ -55,18 +55,18 @@ public class FaceHuggerBehaviour : MonoBehaviour
             {
                 if (!detected)
                 {
-                    Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, enemyDetectedRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
+                    Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, enemyDetectedRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
                 }
                 else
                 {
-                    Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, maxChasingRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
-                    Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, maxAttackRange, new Vector3(0.0f, 0.8f, 1.0f)); //Blue
+                    Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, maxChasingRange, new Vector3(0.9f, 0.0f, 0.9f)); //Purple
+                    Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, maxAttackRange, new Vector3(0.0f, 0.8f, 1.0f)); //Blue
                 }
             }
 
             //Set the director vector and distance to the player
-            directorVector = (playerGO.transform.position - attachedGameObject.transform.position).Normalize();
-            playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+            directorVector = (playerGO.transform.Position - attachedGameObject.transform.Position).Normalize();
+            playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
 
             UpdateFSMStates();
             DoStateBehaviour();
@@ -84,7 +84,7 @@ public class FaceHuggerBehaviour : MonoBehaviour
         if (life <= 0) { currentState = States.Dead; return; }
 
         if (!detected && playerDistance < enemyDetectedRange) detected = true;
-        
+
         if (detected)
         {
             if (currentState == States.Jump)
@@ -92,9 +92,9 @@ public class FaceHuggerBehaviour : MonoBehaviour
                 if (playerDistance > maxAttackRange && playerDistance < maxChasingRange)
                 {
                     currentState = States.Dead;
-                    attachedGameObject.transform.position = new Vector3(attachedGameObject.transform.position.x,
+                    attachedGameObject.transform.Position = new Vector3(attachedGameObject.transform.Position.x,
                                                                         0.0f,
-                                                                        attachedGameObject.transform.position.z);
+                                                                        attachedGameObject.transform.Position.z);
 
                     attachedGameObject.source.Play(IAudioSource.AudioEvent.E_FH_DEATH);
                     detected = false;
@@ -125,7 +125,7 @@ public class FaceHuggerBehaviour : MonoBehaviour
         }
     }
 
-    float maxHeight = 275.0f;
+    readonly float maxHeight = 275.0f;
     float height = 0.0f;
     bool up = true;
     void DoStateBehaviour()
@@ -136,12 +136,12 @@ public class FaceHuggerBehaviour : MonoBehaviour
                 return;
             case States.Attack:
                 player.isFighting = true;
-                attachedGameObject.transform.LookAt2D(playerGO.transform.position);
-                attachedGameObject.transform.Translate(attachedGameObject.transform.forward * movementSpeed * Time.deltaTime);
+                attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
+                attachedGameObject.transform.Translate(attachedGameObject.transform.Forward * movementSpeed * Time.deltaTime);
                 break;
             case States.Jump:
                 player.isFighting = true;
-                attachedGameObject.transform.Translate(attachedGameObject.transform.forward * movementSpeed * 3.0f * Time.deltaTime);
+                attachedGameObject.transform.Translate(attachedGameObject.transform.Forward * movementSpeed * 3.0f * Time.deltaTime);
                 if (up)
                 {
                     if (maxHeight > height)
@@ -159,9 +159,10 @@ public class FaceHuggerBehaviour : MonoBehaviour
                     if (height <= 0)
                     {
                         height = 0.0f;
-                        
+
                     }
-                    else {
+                    else
+                    {
                         attachedGameObject.transform.Translate(Vector3.up * -height * Time.deltaTime);
                         height = height - 20.0f;
                     }
@@ -170,7 +171,7 @@ public class FaceHuggerBehaviour : MonoBehaviour
             case States.Dead:
                 attachedGameObject.transform.Rotate(Vector3.right * 1100.0f); //80 degrees??
                 attachedGameObject.transform.Translate(Vector3.up * -1.0f * Time.deltaTime);
-                
+
                 break;
             default:
                 break;
@@ -180,10 +181,10 @@ public class FaceHuggerBehaviour : MonoBehaviour
     bool hitPlayer = false;
     public void CheckJump() //temporary function for the hardcoding of collisions
     {
-        if(!hitPlayer)
+        if (!hitPlayer)
         {
-        playerGO.GetComponent<PlayerScript>().ReduceLife();
-        hitPlayer = true;
+            playerGO.GetComponent<PlayerScript>().ReduceLife();
+            hitPlayer = true;
         }
     }
 }

--- a/TheOneScripting/GameManager.cs
+++ b/TheOneScripting/GameManager.cs
@@ -36,12 +36,12 @@ public class GameManager : MonoBehaviour
 
     public override void Update()
     {
-        
+
     }
 
     public void SaveSceneState()
     {
-        if(!savedLevels.Contains(SceneManager.GetCurrentSceneName()))
+        if (!savedLevels.Contains(SceneManager.GetCurrentSceneName()))
             savedLevels.Add(SceneManager.GetCurrentSceneName());
 
         InternalCalls.CreateSaveFromScene("GameData/Scenes", SceneManager.GetCurrentSceneName());

--- a/TheOneScripting/Grenade.cs
+++ b/TheOneScripting/Grenade.cs
@@ -6,7 +6,7 @@ public class Grenade : MonoBehaviour
     PlayerScript player;
 
     Vector3 velocity;
-    float lifeTime = 20.0f;
+    readonly float lifeTime = 20.0f;
     float currentTime = 0.0f;
     Vector3 gravity = new Vector3(0f, -110f, 0f);
 
@@ -21,7 +21,7 @@ public class Grenade : MonoBehaviour
     {
         currentTime += Time.deltaTime;
 
-        if (currentTime > lifeTime || attachedGameObject.transform.position.y <= 0)
+        if (currentTime > lifeTime || attachedGameObject.transform.Position.y <= 0)
         {
             currentTime = 0.0f;
             velocity = player.grenadeInitialVelocity;
@@ -29,12 +29,12 @@ public class Grenade : MonoBehaviour
             return;
         }
 
-        Vector3 position = attachedGameObject.transform.position + player.grenadeInitialVelocity * Time.deltaTime;
-        player.grenadeInitialVelocity = player.grenadeInitialVelocity + gravity * Time.deltaTime;
-        
+        Vector3 position = attachedGameObject.transform.Position + player.grenadeInitialVelocity * Time.deltaTime;
+        player.grenadeInitialVelocity += gravity * Time.deltaTime;
+
         attachedGameObject.transform.SetPosition(position);
         Debug.Log(" vel starto 3 = x> " + player.grenadeInitialVelocity.x + " z>" + player.grenadeInitialVelocity.z);
         Debug.LogWarning("Position -> " + position.x + " " + position.y + " " + position.z);
-        Debug.LogWarning("Velocity -> " + velocity.x + " " + velocity.y + " " + velocity.z);      
+        Debug.LogWarning("Velocity -> " + velocity.x + " " + velocity.y + " " + velocity.z);
     }
 }

--- a/TheOneScripting/IAnimator.cs
+++ b/TheOneScripting/IAnimator.cs
@@ -6,7 +6,7 @@ public class IAnimator : IComponent
     public IAnimator() : base() { }
 
     public IAnimator(IntPtr gameObjectRef) : base(gameObjectRef) { }
-    
+
     public void Play(string name)
     {
         InternalCalls.PlayAnimation(containerGOptr, name);
@@ -16,7 +16,7 @@ public class IAnimator : IComponent
         InternalCalls.StopAnimation(containerGOptr);
     }
 
-    public bool currentAnimHasFinished
+    public bool CurrentAnimHasFinished
     {
         get
         {
@@ -24,19 +24,19 @@ public class IAnimator : IComponent
         }
     }
 
-    public bool blend 
-    { 
-        get 
+    public bool Blend
+    {
+        get
         {
             return InternalCalls.GetTransitionBlend(containerGOptr);
         }
-        set 
+        set
         {
             InternalCalls.SetTransitionBlend(containerGOptr, ref value);
         }
     }
 
-    public float transitionTime
+    public float TransitionTime
     {
         get
         {

--- a/TheOneScripting/IAudioSource.cs
+++ b/TheOneScripting/IAudioSource.cs
@@ -187,7 +187,7 @@ public class IAudioSource : IComponent
 
     public IAudioSource() : base() { }
     public IAudioSource(IntPtr GOptr) : base(GOptr) { }
-    
+
     public AudioEvent currentID = 0;
     public void Play(AudioEvent audio)
     {

--- a/TheOneScripting/ICanvas.cs
+++ b/TheOneScripting/ICanvas.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 
-
 public class ICanvas : IComponent
 {
     public enum UiState
@@ -16,7 +15,7 @@ public class ICanvas : IComponent
     public ICanvas() : base() { }
     public ICanvas(IntPtr gameObjectRef) : base(gameObjectRef) { }
 
-    public void ToggleEnable() 
+    public void ToggleEnable()
     {
         InternalCalls.CanvasEnableToggle(containerGOptr);
     }

--- a/TheOneScripting/IComponent.cs
+++ b/TheOneScripting/IComponent.cs
@@ -22,6 +22,6 @@ public class IComponent : IObject
         Unknown
     }
 
-   public IComponent() : base() { }
-   public IComponent(IntPtr gameObjectRef) : base(gameObjectRef) { }
+    public IComponent() : base() { }
+    public IComponent(IntPtr gameObjectRef) : base(gameObjectRef) { }
 }

--- a/TheOneScripting/IGameObject.cs
+++ b/TheOneScripting/IGameObject.cs
@@ -37,7 +37,7 @@ public class IGameObject : IObject
     {
         IntPtr foundGOptr = InternalCalls.FindGameObject(name);
 
-        if(foundGOptr == IntPtr.Zero)
+        if (foundGOptr == IntPtr.Zero)
         {
             Debug.LogError("GameObject with name '" + name + "' not found.");
 
@@ -45,7 +45,7 @@ public class IGameObject : IObject
         }
 
         IGameObject goToReturn = new IGameObject(foundGOptr);
-        
+
         return goToReturn;
     }
 
@@ -77,7 +77,7 @@ public class IGameObject : IObject
         {
             component = InternalCalls.ComponentCheck(containerGOptr, (int)type);
 
-            if (component != IntPtr.Zero) 
+            if (component != IntPtr.Zero)
             {
 
                 switch (type)
@@ -132,7 +132,7 @@ public class IGameObject : IObject
             }
         }
 
-        
+
         if (componentToReturn != null)
         {
             return componentToReturn;

--- a/TheOneScripting/IObject.cs
+++ b/TheOneScripting/IObject.cs
@@ -26,7 +26,7 @@ public class IObject
     {
         containerGOptr = InternalCalls.GetGameObjectPtr();
     }
-    
+
     public IObject(IntPtr gameObjectRef)
     {
         containerGOptr = gameObjectRef;

--- a/TheOneScripting/ITransform.cs
+++ b/TheOneScripting/ITransform.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 public class ITransform : IComponent
 {
-    public Vector3 position
+    public Vector3 Position
     {
         get
         {
@@ -15,7 +15,7 @@ public class ITransform : IComponent
         }
     }
 
-    public Vector3 rotation
+    public Vector3 Rotation
     {
         get
         {
@@ -27,14 +27,14 @@ public class ITransform : IComponent
         }
     }
 
-    public Vector3 forward
+    public Vector3 Forward
     {
         get
         {
             return InternalCalls.GetTransformForward(containerGOptr);
         }
     }
-    public Vector3 right
+    public Vector3 Right
     {
         get
         {
@@ -53,44 +53,44 @@ public class ITransform : IComponent
     {
         //This implementation is temporary, engine Transform.Translate is not working properly.
 
-        Vector3 finalPos = position + increment;
+        Vector3 finalPos = Position + increment;
         InternalCalls.Translate(containerGOptr, ref finalPos);
     }
 
     public void SetPosition(Vector3 setPos)
     {
-        position = setPos;
+        Position = setPos;
     }
 
     public void Rotate(Vector3 increment)
     {
-       InternalCalls.Rotate(containerGOptr, ref increment);
+        InternalCalls.Rotate(containerGOptr, ref increment);
     }
 
 
     public void LookAt2D(Vector3 targetPosition)
     {
-        Vector3 directorVector = targetPosition - position;
+        Vector3 directorVector = targetPosition - Position;
 
         if (directorVector == Vector3.zero) return;
 
         float targetAngle = (float)Math.Atan2(directorVector.x, directorVector.z);
 
-        rotation = new Vector3(0.0f, targetAngle, 0.0f);
+        Rotation = new Vector3(0.0f, targetAngle, 0.0f);
     }
 
     public void CamLookAt(Vector3 targetPosition)
     {
-        Vector3 directorVector = targetPosition - position;
+        Vector3 directorVector = targetPosition - Position;
 
         if (directorVector == Vector3.zero) return;
 
         float distanceXZ = (float)Math.Sqrt(directorVector.x * directorVector.x + directorVector.z * directorVector.z);
 
         float angleY = -(float)Math.Atan2(directorVector.x, directorVector.z);
-        float angleX =  (float)Math.Atan2(directorVector.y, distanceXZ);
+        float angleX = (float)Math.Atan2(directorVector.y, distanceXZ);
 
-        rotation = Vector3.zero;
+        Rotation = Vector3.zero;
         Rotate(new Vector3(angleX * 180.0f / (float)Math.PI, angleY * 180.0f / (float)Math.PI, 0.0f));
     }
 }

--- a/TheOneScripting/Input.cs
+++ b/TheOneScripting/Input.cs
@@ -4,90 +4,90 @@ using System.Runtime.CompilerServices;
 public class Input
 {
 
-	public enum KeyboardCode
-	{
-		A = 4,
-		D = 7,
-		S = 22,
-		W = 26,
-		E = 8,
-		F = 9,
-		G = 10,
-		K = 14,
-		I = 12,
-		Q = 20,
-		R = 21,
-		T = 23,
-		F1 = 58,
-		F2 = 59,
-		F3 = 60,
-		RIGHT = 79,
-		LEFT = 80,
-		DOWN = 81,
-		UP = 82,
-		SPACEBAR = 44,
-		ESCAPE = 41,
-		RETURN = 40,
-		LSHIFT = 225,
-		//Test abilities TO DELETE when changed
-		ONE = 30,
-		TWO = 31,
+    public enum KeyboardCode
+    {
+        A = 4,
+        D = 7,
+        S = 22,
+        W = 26,
+        E = 8,
+        F = 9,
+        G = 10,
+        K = 14,
+        I = 12,
+        Q = 20,
+        R = 21,
+        T = 23,
+        F1 = 58,
+        F2 = 59,
+        F3 = 60,
+        RIGHT = 79,
+        LEFT = 80,
+        DOWN = 81,
+        UP = 82,
+        SPACEBAR = 44,
+        ESCAPE = 41,
+        RETURN = 40,
+        LSHIFT = 225,
+        //Test abilities TO DELETE when changed
+        ONE = 30,
+        TWO = 31,
         THREE = 32,
         FOUR = 33,
         FIVE = 34,
         SIX = 35,
-	}
+    }
 
-	public enum MouseButtonCode
-	{
-		LEFT = 1,
-		MIDDLE,
-		RIGHT
-	}
+    public enum MouseButtonCode
+    {
+        LEFT = 1,
+        MIDDLE,
+        RIGHT
+    }
 
-	public enum ControllerButtonCode
-	{
-		A = 0,
-		B = 1,
-		X = 2,
-		Y = 3,
-		BACK = 4,
-		GUIDE = 5,
-		START = 6,
-		L3 = 7,
-		R3 = 8,
-		L1 = 9,
-		R1 = 10,
-		UP = 11,
-		DOWN = 12,
-		LEFT = 13,
-		RIGHT = 14,
+    public enum ControllerButtonCode
+    {
+        A = 0,
+        B = 1,
+        X = 2,
+        Y = 3,
+        BACK = 4,
+        GUIDE = 5,
+        START = 6,
+        L3 = 7,
+        R3 = 8,
+        L1 = 9,
+        R1 = 10,
+        UP = 11,
+        DOWN = 12,
+        LEFT = 13,
+        RIGHT = 14,
 
-		L2 = 22,
-		R2 = 23,
-	}
+        L2 = 22,
+        R2 = 23,
+    }
 
-	public enum ControllerJoystickCode
-	{
-		JOY_LEFT,
-		JOY_RIGHT,
-	}
+    public enum ControllerJoystickCode
+    {
+        JOY_LEFT,
+        JOY_RIGHT,
+    }
 
-	public static bool GetKeyboardButton(KeyboardCode key)
-	{
-		return InternalCalls.GetKeyboardButton((int) key);
-	}
+    public static bool GetKeyboardButton(KeyboardCode key)
+    {
+        return InternalCalls.GetKeyboardButton((int)key);
+    }
 
-	public static bool GetControllerButton(ControllerButtonCode button, int controller = 0)
-	{
-		return InternalCalls.GetControllerButton((int)button, controller);
-	}
+    public static bool GetControllerButton(ControllerButtonCode button, int controller = 0)
+    {
+        return InternalCalls.GetControllerButton((int)button, controller);
+    }
 
-	public static Vector2 GetControllerJoystick(ControllerJoystickCode joystick, int controller = 0)
-	{
-		Vector2 joyResult = Vector2.zero;
-		InternalCalls.GetControllerJoystick((int)joystick, ref joyResult, controller);
-		return joyResult;
-	}
+    public static Vector2 GetControllerJoystick(ControllerJoystickCode joystick, int controller = 0)
+    {
+        Vector2 joyResult = Vector2.zero;
+        InternalCalls.GetControllerJoystick((int)joystick, ref joyResult, controller);
+        return joyResult;
+    }
 }
 

--- a/TheOneScripting/InternalCalls.cs
+++ b/TheOneScripting/InternalCalls.cs
@@ -59,7 +59,7 @@ class InternalCalls
     #region GameObject
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static IGameObject InstantiateBullet(Vector3 initialPosition, Vector3 direction);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static IGameObject InstantiateGrenade(Vector3 initialPosition, Vector3 direction);
 
@@ -80,7 +80,7 @@ class InternalCalls
 
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static IntPtr ComponentCheck(IntPtr gameObject, int componentType, string scriptName = null);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static TComponent GetScript<TComponent>(IntPtr gameObject, string scriptName);
 
@@ -155,7 +155,7 @@ class InternalCalls
 
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static int ToggleChecker(IntPtr GOptr, bool value, string nameM);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static int PrintItemUI(IntPtr GOptr, bool value, string nameM);
 
@@ -184,7 +184,7 @@ class InternalCalls
     #region Helpers
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static float GetAppDeltaTime();
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static void ExitApplication();
     #endregion
@@ -192,10 +192,10 @@ class InternalCalls
     #region Debug
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static void ScriptingLog(string message, int logType);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static void DrawWireCircle(Vector3 position, float radius, Vector3 color);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static void DrawWireSphere(Vector3 position, float radius, Vector3 color);
 
@@ -258,31 +258,31 @@ class InternalCalls
 
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static void SetFov(IntPtr GOptr, ref double fov);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static double GetAspect(IntPtr GOptr);
 
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static void SetAspect(IntPtr GOptr, ref double aspect);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static float GetYaw(IntPtr GOptr);
 
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static void SetYaw(IntPtr GOptr, ref float yaw);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static float GetPitch(IntPtr GOptr);
 
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static void SetPitch(IntPtr GOptr, ref float pitch);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static CameraType GetCameraType(IntPtr GOptr);
 
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static void SetCameraType(IntPtr GOptr, ref CameraType cameraType);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static bool GetPrimaryCam(IntPtr GOptr);
 
@@ -296,10 +296,10 @@ class InternalCalls
 
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static void StopAnimation(IntPtr GOptr);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static bool AnimationHasFinished(IntPtr GOptr);
-    
+
     [MethodImplAttribute(MethodImplOptions.InternalCall)]
     internal extern static bool GetTransitionBlend(IntPtr GOptr);
 

--- a/TheOneScripting/IntroScene.cs
+++ b/TheOneScripting/IntroScene.cs
@@ -35,15 +35,15 @@ class IntroScene : MonoBehaviour
     public override void Update()
     {
         timerScene += Time.deltaTime;
-        
-        if(timerScene >= durationScene)
+
+        if (timerScene >= durationScene)
         {
             canvasText.PrintItemUI(true, "ContinueTxt");
 
             if (Input.GetKeyboardButton(Input.KeyboardCode.RETURN) ||
             Input.GetControllerButton(Input.ControllerButtonCode.X))
             {
-                if(state == IntroSceneStates.INTRO)
+                if (state == IntroSceneStates.INTRO)
                 {
                     state = IntroSceneStates.DIALOG;
                     canvasText.PrintItemUI(false, "IntroImg");
@@ -62,7 +62,7 @@ class IntroScene : MonoBehaviour
                             break;
                         }
 
-                        string[] datapath = {"NarrativeIntro", "Dialog" +  dialogNum.ToString() };
+                        string[] datapath = { "NarrativeIntro", "Dialog" + dialogNum.ToString() };
                         string text = DataManager.AccessFileDataString(filepath, datapath, "dialoguer");
                         text += DataManager.AccessFileDataString(filepath, datapath, "text");
                         canvasText.SetTextString(text, "SubtitlesTxt");

--- a/TheOneScripting/ItemManager.cs
+++ b/TheOneScripting/ItemManager.cs
@@ -95,7 +95,7 @@ public class ItemManager : MonoBehaviour
                 {
                     equipped.Remove(kvp.Key);
                     Debug.Log("Item id: '" + id + "' unequipped from slot " + kvp.Key + ".");
-               
+
                     break;
                 }
             }
@@ -126,8 +126,7 @@ public class ItemManager : MonoBehaviour
 
     private bool CheckItemInItemData(uint id)
     {
-        Item item;
-        if (itemData.TryGetValue(id, out item)) return true;
+        if (itemData.TryGetValue(id, out _)) return true;
 
         return false;
     }

--- a/TheOneScripting/Item_M4A1.cs
+++ b/TheOneScripting/Item_M4A1.cs
@@ -8,7 +8,7 @@ class Item_M4A1 : Item
 {
     uint damage = 6;
 
-    public Item_M4A1() 
+    public Item_M4A1()
     {
         this.id = 1;
         this.name = "M4A1";
@@ -23,4 +23,3 @@ class Item_M4A1 : Item
 
     }
 }
-

--- a/TheOneScripting/MainMenuManager.cs
+++ b/TheOneScripting/MainMenuManager.cs
@@ -6,6 +6,9 @@ public class MainMenuManager : MonoBehaviour
     public ICanvas canvasLogo;
     public ICanvas canvasTitle;
     public ICanvas canvasCredits;
+
+    UiScriptSettings settingsScript;
+
     float cooldown = 0;
     bool onCooldown = false;
 
@@ -33,6 +36,8 @@ public class MainMenuManager : MonoBehaviour
         canvasTitle = IGameObject.Find("TitleCanvas").GetComponent<ICanvas>();
         canvasCredits = IGameObject.Find("CreditsCanvas").GetComponent<ICanvas>();
 
+        settingsScript = IGameObject.Find("Canvas_Settings").GetComponent<UiScriptSettings>();
+
         IGameObject.Find("Canvas_Settings").Disable();
         IGameObject.Find("Canvas_SettingsControls").Disable();
         IGameObject.Find("Canvas_SettingsDisplay").Disable();
@@ -58,7 +63,6 @@ public class MainMenuManager : MonoBehaviour
         float dt = Time.realDeltaTime;
         bool toMove = false;
         int direction = 0;
-        UiScriptSettings settingsScript = IGameObject.Find("Canvas_Settings").GetComponent<UiScriptSettings>();
 
         if (wasEditing && !settingsScript.editing) onCooldown = true;
 

--- a/TheOneScripting/PlayerScript.cs
+++ b/TheOneScripting/PlayerScript.cs
@@ -23,12 +23,14 @@ public class PlayerScript : MonoBehaviour
     IGameObject iShotPSGO;
     IGameObject iStepPSGO;
 
+    IParticleSystem stepParticles;
+    IParticleSystem shotParticles;
 
     // background music
     public bool isFighting = false;
     public bool onPause = false;
     float timeAfterCombat = 0;
-    float maxTimeAfterCombat = 5.0f;
+    readonly float maxTimeAfterCombat = 5.0f;
 
 
     // stats
@@ -45,8 +47,6 @@ public class PlayerScript : MonoBehaviour
     public Vector3 movementDirection;
     public Vector3 lastMovementDirection;
     public float movementMagnitude;
-    bool lastFrameRunned = false;
-
 
     // shooting
     public float damageM4 = 10.0f;
@@ -101,8 +101,8 @@ public class PlayerScript : MonoBehaviour
         iStepPSGO = attachedGameObject.FindInChildren("StepsPS");
 
         attachedGameObject.animator.Play("Idle");
-        attachedGameObject.animator.blend = false;
-        attachedGameObject.animator.transitionTime = 0.0f;
+        attachedGameObject.animator.Blend = false;
+        attachedGameObject.animator.TransitionTime = 0.0f;
 
         life = maxLife;
         speed = baseSpeed;
@@ -111,6 +111,9 @@ public class PlayerScript : MonoBehaviour
         attachedGameObject.source.SetState(IAudioSource.AudioStateGroup.GAMEPLAYMODE, IAudioSource.AudioStateID.SHIP);
         attachedGameObject.source.SetSwitch(IAudioSource.AudioSwitchGroup.SURFACETYPE, IAudioSource.AudioSwitchID.SHIP);
         attachedGameObject.source.Play(IAudioSource.AudioEvent.PLAYMUSIC);
+
+        stepParticles = iStepPSGO?.GetComponent<IParticleSystem>();
+        shotParticles = iShotPSGO?.GetComponent<IParticleSystem>();
     }
 
     public override void Update()
@@ -197,14 +200,11 @@ public class PlayerScript : MonoBehaviour
         else
         {
             //attachedGameObject.source.Stop(IAudioSource.AudioEvent.P_STEP);
-            if (iStepPSGO != null)
-            {
-                iStepPSGO.GetComponent<IParticleSystem>().End();
-            }
+            stepParticles.End();
         }
 
         // current weapon switch
-        switch(currentWeapon)
+        switch (currentWeapon)
         {
             case CurrentWeapon.MP4:
                 break;
@@ -254,18 +254,15 @@ public class PlayerScript : MonoBehaviour
     private void Step()
     {
         attachedGameObject.source.Play(IAudioSource.AudioEvent.P_STEP);
-        if (iStepPSGO != null)
-        {
-            iStepPSGO.GetComponent<IParticleSystem>().Play();
-        }
+        stepParticles.Play();
     }
 
-    private void Die()
-    {
-        attachedGameObject.transform.Rotate(Vector3.right * 90.0f);
-        attachedGameObject.animator.Play("Death");
-        // play sound (?)
-    }
+    //private void Die()
+    //{
+    //    attachedGameObject.transform.Rotate(Vector3.right * 90.0f);
+    //    attachedGameObject.animator.Play("Death");
+    //    // play sound (?)
+    //}
     private bool SetMoveDirection()
     {
         bool toMove = false;
@@ -333,7 +330,7 @@ public class PlayerScript : MonoBehaviour
             lastMovementDirection = movementDirection;
             aimingDirection = aimingDirection.Normalize();
             float characterRotation = (float)Math.Atan2(aimingDirection.x, aimingDirection.y);
-            attachedGameObject.transform.rotation = new Vector3(0.0f, characterRotation, 0.0f);
+            attachedGameObject.transform.Rotation = new Vector3(0.0f, characterRotation, 0.0f);
 
         }
 
@@ -387,7 +384,7 @@ public class PlayerScript : MonoBehaviour
         {
             aimingDirection = aimingDirection.Normalize();
             float characterRotation = (float)Math.Atan2(aimingDirection.x, aimingDirection.y);
-            attachedGameObject.transform.rotation = new Vector3(0.0f, characterRotation, 0.0f);
+            attachedGameObject.transform.Rotation = new Vector3(0.0f, characterRotation, 0.0f);
         }
     }
 
@@ -400,10 +397,10 @@ public class PlayerScript : MonoBehaviour
             timeSinceLastShot += Time.deltaTime;
             if (!hasShot && timeSinceLastShot > shootingCooldown / 2)
             {
-                InternalCalls.InstantiateBullet(attachedGameObject.transform.position + attachedGameObject.transform.forward * 13.5f + height, attachedGameObject.transform.rotation);
+                InternalCalls.InstantiateBullet(attachedGameObject.transform.Position + attachedGameObject.transform.Forward * 13.5f + height, attachedGameObject.transform.Rotation);
                 attachedGameObject.source.Play(IAudioSource.AudioEvent.W_M4_SHOOT);
                 hasShot = true;
-                if (iShotPSGO != null) iShotPSGO.GetComponent<IParticleSystem>().Replay();
+                shotParticles.Replay();
 
                 if (currentWeapon == CurrentWeapon.IMPACIENTE)
                     impacienteBulletCounter++;

--- a/TheOneScripting/RedXenomorphBehaviour.cs
+++ b/TheOneScripting/RedXenomorphBehaviour.cs
@@ -65,8 +65,8 @@ public class RedXenomorphBehaviour : MonoBehaviour
         gameManager = IGameObject.Find("GameManager").GetComponent<GameManager>();
 
         attachedGameObject.animator.Play("Walk");
-        attachedGameObject.animator.blend = false;
-        attachedGameObject.animator.transitionTime = 0.0f;
+        attachedGameObject.animator.Blend = false;
+        attachedGameObject.animator.TransitionTime = 0.0f;
 
         acidSpitPSGO = attachedGameObject.FindInChildren("AcidSpitPS");
         tailAttackPSGO = attachedGameObject.FindInChildren("TailAttackPS");
@@ -84,8 +84,8 @@ public class RedXenomorphBehaviour : MonoBehaviour
             DebugDraw();
 
             //Set the director vector and distance to the player
-            directorVector = (playerGO.transform.position - attachedGameObject.transform.position).Normalize();
-            playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+            directorVector = (playerGO.transform.Position - attachedGameObject.transform.Position).Normalize();
+            playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
 
             UpdateFSM();
             DoStateBehaviour();
@@ -104,7 +104,7 @@ public class RedXenomorphBehaviour : MonoBehaviour
 
         if (detected)
         {
-            attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+            attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
             if (playerDistance < isCloseRange && !isClose)
             {
                 isClose = true;
@@ -165,7 +165,7 @@ public class RedXenomorphBehaviour : MonoBehaviour
                 break;
             case States.Chase:
                 player.isFighting = true;
-                attachedGameObject.transform.Translate(attachedGameObject.transform.forward * movementSpeed * Time.deltaTime);
+                attachedGameObject.transform.Translate(attachedGameObject.transform.Forward * movementSpeed * Time.deltaTime);
                 break;
             case States.Patrol:
                 Patrol();
@@ -206,7 +206,7 @@ public class RedXenomorphBehaviour : MonoBehaviour
         //InternalCalls.InstantiateBullet(attachedGameObject.transform.position + attachedGameObject.transform.forward * 12.5f, attachedGameObject.transform.rotation);
         //attachedGameObject.source.PlayAudio(IAudioSource.EventIDs.E_X_ADULT_SPIT);
 
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             ResetState();
         }
@@ -214,7 +214,7 @@ public class RedXenomorphBehaviour : MonoBehaviour
 
     private void TailStab()
     {
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             ResetState();
         }
@@ -262,9 +262,9 @@ public class RedXenomorphBehaviour : MonoBehaviour
     private bool MoveTo(Vector3 targetPosition)
     {
         //Return true if arrived at destination
-        if (Vector3.Distance(attachedGameObject.transform.position, targetPosition) < 0.5f) return true;
+        if (Vector3.Distance(attachedGameObject.transform.Position, targetPosition) < 0.5f) return true;
 
-        Vector3 dirVector = (targetPosition - attachedGameObject.transform.position).Normalize();
+        Vector3 dirVector = (targetPosition - attachedGameObject.transform.Position).Normalize();
         attachedGameObject.transform.Translate(dirVector * movementSpeed * Time.deltaTime);
         //attachedGameObject.source.PlayAudio(AudioManager.EventIDs.E_REBEL_STEP);
         return false;
@@ -277,12 +277,12 @@ public class RedXenomorphBehaviour : MonoBehaviour
         {
             if (!detected)
             {
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, detectedRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, detectedRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
             }
             else
             {
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, isCloseRange, new Vector3(1.0f, 0.0f, 0.0f)); //Red
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, maxChasingRange, new Vector3(1.0f, 0.0f, 1.0f)); //Purple
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, isCloseRange, new Vector3(1.0f, 0.0f, 0.0f)); //Red
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, maxChasingRange, new Vector3(1.0f, 0.0f, 1.0f)); //Purple
             }
         }
     }

--- a/TheOneScripting/SceneManager.cs
+++ b/TheOneScripting/SceneManager.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 
-public class SceneManager {
-
-    public static void LoadScene(string sceneName, bool keep = true, string path = "GameData/Scenes/") {
+public class SceneManager
+{
+    public static void LoadScene(string sceneName, bool keep = true, string path = "GameData/Scenes/")
+    {
         InternalCalls.LoadScene(sceneName, keep, path);
     }
 
-    public static string GetCurrentSceneName() {
+    public static string GetCurrentSceneName()
+    {
         return InternalCalls.GetCurrentSceneName();
     }
 

--- a/TheOneScripting/Time.cs
+++ b/TheOneScripting/Time.cs
@@ -3,24 +3,24 @@ using System.Runtime.CompilerServices;
 
 public class Time
 {
-	const float maxDeltaTime = 0.5f;
-	public static float deltaTime
-	{
-		get
-		{
-			if(InternalCalls.GetAppDeltaTime() > maxDeltaTime)
-			{
-				return maxDeltaTime;
-			}
-			else { return InternalCalls.GetAppDeltaTime(); }
-		}
-	}
+    const float maxDeltaTime = 0.5f;
+    public static float deltaTime
+    {
+        get
+        {
+            if (InternalCalls.GetAppDeltaTime() > maxDeltaTime)
+            {
+                return maxDeltaTime;
+            }
+            else { return InternalCalls.GetAppDeltaTime(); }
+        }
+    }
 
-	public static float realDeltaTime
-	{
-		get
-		{
-			return InternalCalls.GetAppDeltaTime();
-		}
-	}
+    public static float realDeltaTime
+    {
+        get
+        {
+            return InternalCalls.GetAppDeltaTime();
+        }
+    }
 }

--- a/TheOneScripting/UiManager.cs
+++ b/TheOneScripting/UiManager.cs
@@ -43,11 +43,17 @@ public class UiManager : MonoBehaviour
     IGameObject savingSceneGo;
     IGameObject pickUpFeedbackGo;
 
+    UiScriptSettings settingsCanvas;
+
     IGameObject playerGO;
     PlayerScript playerScript;
 
     IGameObject GameManagerGO;
     GameManager gameManager;
+
+    ICanvas savingCanvas;
+    ICanvas dialogCanvas;
+    ICanvas pickupCanvas;
 
     MenuState state;
     MenuState previousState;
@@ -106,6 +112,11 @@ public class UiManager : MonoBehaviour
 
         GameManagerGO = IGameObject.Find("GameManager");
         gameManager = GameManagerGO.GetComponent<GameManager>();
+        savingCanvas = savingSceneGo.GetComponent<ICanvas>();
+        dialogCanvas = dialogueGo.GetComponent<ICanvas>();
+        pickupCanvas = pickUpFeedbackGo.GetComponent<ICanvas>();
+
+        settingsCanvas = settingsGo.GetComponent<UiScriptSettings>();
     }
 
     public override void Update()
@@ -129,20 +140,20 @@ public class UiManager : MonoBehaviour
 
             if (changeSaveTextCooldown > 2.0f)
             {
-                savingSceneGo.GetComponent<ICanvas>().SetTextString("saving progress", "Text_SavingProgress");
+                savingCanvas.SetTextString("saving progress", "Text_SavingProgress");
                 changeSaveTextCooldown = 0.0f;
             }
             else if (changeSaveTextCooldown > 1.5f)
             {
-                savingSceneGo.GetComponent<ICanvas>().SetTextString("saving progress...", "Text_SavingProgress");
+                savingCanvas.SetTextString("saving progress...", "Text_SavingProgress");
             }
             else if (changeSaveTextCooldown > 1.0f)
             {
-                savingSceneGo.GetComponent<ICanvas>().SetTextString("saving progress..", "Text_SavingProgress");
+                savingCanvas.SetTextString("saving progress..", "Text_SavingProgress");
             }
             else if (changeSaveTextCooldown > 0.5f)
             {
-                savingSceneGo.GetComponent<ICanvas>().SetTextString("saving progress.", "Text_SavingProgress");
+                savingCanvas.SetTextString("saving progress.", "Text_SavingProgress");
             }
 
             if (state != MenuState.Hud)
@@ -231,7 +242,7 @@ public class UiManager : MonoBehaviour
                     }
                     onCooldown = true;
                 }
-                else if(Input.GetKeyboardButton(Input.KeyboardCode.K))
+                else if (Input.GetKeyboardButton(Input.KeyboardCode.K))
                 {
                     if (previousState == MenuState.Debug)
                     {
@@ -246,7 +257,7 @@ public class UiManager : MonoBehaviour
                 else if (Input.GetKeyboardButton(Input.KeyboardCode.ESCAPE))
                 {
                     attachedGameObject.source.Play(IAudioSource.AudioEvent.UI_PAUSEGAME);
-                    if (!settingsGo.GetComponent<UiScriptSettings>().editing)
+                    if (!settingsCanvas.editing)
                     {
                         if (state == MenuState.Pause)
                         {
@@ -383,7 +394,7 @@ public class UiManager : MonoBehaviour
                     break;
                 case MenuState.Settings:
                     settingsGo.Enable();
-                    settingsGo.GetComponent<UiScriptSettings>().firstFrameUpdate = false;
+                    settingsCanvas.firstFrameUpdate = false;
                     playerScript.onPause = true;
                     break;
                 case MenuState.Missions:
@@ -409,38 +420,38 @@ public class UiManager : MonoBehaviour
                     break;
                 savingSceneGo.Enable();
                 if (text == "") text = "saving progress";
-                savingSceneGo.GetComponent<ICanvas>().SetTextString(text, "Text_SavingProgress");
+                savingCanvas.SetTextString(text, "Text_SavingProgress");
                 saveOnCooldown = true;
                 break;
             case HudPopUpMenu.PickUpFeedback:
                 if (pickUpFeedbackOnCooldown)
                     break;
                 pickUpFeedbackGo.Enable();
-                pickUpFeedbackGo.GetComponent<ICanvas>().SetTextString(text, "Text_PickedItem");
+                pickupCanvas.SetTextString(text, "Text_PickedItem");
                 pickUpFeedbackOnCooldown = true;
                 break;
             case HudPopUpMenu.Dialogue:
-                if(dialogueOnCooldown)
+                if (dialogueOnCooldown)
                     break;
                 dialogueGo.Enable();
-                dialogueGo.GetComponent<ICanvas>().SetTextString(text, "Text_Dialogue");
-                dialogueGo.GetComponent<ICanvas>().PrintItemUI(false, "Img_ShopKeeper");
-                dialogueGo.GetComponent<ICanvas>().PrintItemUI(false, "Img_Medic");
-                dialogueGo.GetComponent<ICanvas>().PrintItemUI(false, "Img_CampLeader");
-                dialogueGo.GetComponent<ICanvas>().PrintItemUI(false, "Img_Sargeant");
+                dialogCanvas.SetTextString(text, "Text_Dialogue");
+                dialogCanvas.PrintItemUI(false, "Img_ShopKeeper");
+                dialogCanvas.PrintItemUI(false, "Img_Medic");
+                dialogCanvas.PrintItemUI(false, "Img_CampLeader");
+                dialogCanvas.PrintItemUI(false, "Img_Sargeant");
                 switch (dialoguer)
                 {
                     case Dialoguer.ShopKeeper:
-                dialogueGo.GetComponent<ICanvas>().PrintItemUI(true, "Img_ShopKeeper");
+                        dialogCanvas.PrintItemUI(true, "Img_ShopKeeper");
                         break;
                     case Dialoguer.Medic:
-                dialogueGo.GetComponent<ICanvas>().PrintItemUI(true, "Img_Medic");
+                        dialogCanvas.PrintItemUI(true, "Img_Medic");
                         break;
                     case Dialoguer.CampLeader:
-                dialogueGo.GetComponent<ICanvas>().PrintItemUI(true, "Img_CampLeader");
+                        dialogCanvas.PrintItemUI(true, "Img_CampLeader");
                         break;
                     case Dialoguer.Sargeant:
-                dialogueGo.GetComponent<ICanvas>().PrintItemUI(true, "Img_Sargeant");
+                        dialogCanvas.PrintItemUI(true, "Img_Sargeant");
                         break;
                     default:
                         break;

--- a/TheOneScripting/UiScriptDebug.cs
+++ b/TheOneScripting/UiScriptDebug.cs
@@ -6,13 +6,8 @@ public class UiScriptDebug : MonoBehaviour
     float cooldown = 0;
     bool onCooldown = false;
 
-    IGameObject playerGO;
-    PlayerScript player;
-
     IGameObject GameManagerGO;
     GameManager gameManager;
-
-    UiManager menuManager;
 
     public UiScriptDebug()
     {
@@ -21,11 +16,6 @@ public class UiScriptDebug : MonoBehaviour
 
     public override void Start()
     {
-        playerGO = IGameObject.Find("SK_MainCharacter");
-        player = playerGO.GetComponent<PlayerScript>();
-
-        menuManager = IGameObject.Find("UI_Manager").GetComponent<UiManager>();
-
         GameManagerGO = IGameObject.Find("GameManager");
         gameManager = GameManagerGO.GetComponent<GameManager>();
 

--- a/TheOneScripting/UiScriptHud.cs
+++ b/TheOneScripting/UiScriptHud.cs
@@ -29,27 +29,27 @@ public class UiScriptHud : MonoBehaviour
     string kills;
 
     string currLoadout = "m41a";
-    float currAmmo = 20;
-    float maxAmmo = 20;
+    int currAmmo = 20;
+    int maxAmmo = 20;
     string ammo;
 
-    bool  grenadeOnCooldown = false;
+    bool grenadeOnCooldown = false;
     float grenadeCooldown = 5.0f;
     float grenadeTimer = 0.0f;
 
-    bool  painlessOnCooldown = false;
+    bool painlessOnCooldown = false;
     float painlessCooldown = 5.0f;
     float painlessTimer = 0.0f;
 
-    bool  flameThrowerOnCooldown = false;
+    bool flameThrowerOnCooldown = false;
     float flameThrowerCooldown = 5.0f;
     float flameThrowerTimer = 0.0f;
 
-    bool  adrenalineOnCooldown = false;
+    bool adrenalineOnCooldown = false;
     float adrenalineCooldown = 5.0f;
     float adrenalineTimer = 0.0f;
 
-    bool  consumibleOnCooldown = false;
+    bool consumibleOnCooldown = false;
     float consumibleCooldown = 5.0f;
     float consumibleTimer = 0.0f;
 
@@ -97,9 +97,9 @@ public class UiScriptHud : MonoBehaviour
             UpdateTimers();
 
             //setting texts
-            ammo = currAmmo.ToString() + " / " + maxAmmo.ToString();
-            currency = currencyAmount.ToString();
-            kills = killsAmount.ToString();
+            //ammo = currAmmo.ToString() + " / " + maxAmmo.ToString();
+            //currency = currencyAmount.ToString();
+            //kills = killsAmount.ToString();
 
             canvas.SetTextString(ammo, "Text_AmmoAmount");
             canvas.SetTextString(currLoadout, "Text_CurrentLoadoutName");
@@ -157,7 +157,8 @@ public class UiScriptHud : MonoBehaviour
     //for the moment, only for canvas states porpuses
     public void UpdateAbilityCanvas(PlayerAbility ability, ICanvas.UiState state)
     {
-        switch (ability) {
+        switch (ability)
+        {
             case PlayerAbility.GRENADE:
                 if (!grenadeOnCooldown && state == ICanvas.UiState.HOVERED)
                 {

--- a/TheOneScripting/UiScriptHud.cs
+++ b/TheOneScripting/UiScriptHud.cs
@@ -23,11 +23,15 @@ public class UiScriptHud : MonoBehaviour
     float playerMaxLife = 100;
 
     int currencyAmount = 200;
-    int kilsAmount = 0;
+    string currency;
+
+    int killsAmount = 0;
+    string kills;
 
     string currLoadout = "m41a";
     float currAmmo = 20;
     float maxAmmo = 20;
+    string ammo;
 
     bool  grenadeOnCooldown = false;
     float grenadeCooldown = 5.0f;
@@ -77,7 +81,7 @@ public class UiScriptHud : MonoBehaviour
         playerMaxLife = 100;
 
         currencyAmount = 200;
-        kilsAmount = 0;
+        killsAmount = 0;
 
         currLoadout = "m41a";
         currAmmo = 20;
@@ -93,19 +97,23 @@ public class UiScriptHud : MonoBehaviour
             UpdateTimers();
 
             //setting texts
-            canvas.SetTextString(currAmmo.ToString() + " / " + maxAmmo.ToString(), "Text_AmmoAmount");
+            ammo = currAmmo.ToString() + " / " + maxAmmo.ToString();
+            currency = currencyAmount.ToString();
+            kills = killsAmount.ToString();
+
+            canvas.SetTextString(ammo, "Text_AmmoAmount");
             canvas.SetTextString(currLoadout, "Text_CurrentLoadoutName");
             canvas.SetTextString(currentMissionTitle, "Text_MissionName");
             canvas.SetTextString(currentMissionDescription, "Text_MissionDescription");
-            canvas.SetTextString(currencyAmount.ToString(), "Text_CurrencyAmount");
-            canvas.SetTextString(kilsAmount.ToString(), "Text_KillsAmount");
+            canvas.SetTextString(currency, "Text_CurrencyAmount");
+            canvas.SetTextString(kills, "Text_KillsAmount");
 
 
 
             currLife = playerScript.CurrentLife();
             int sliderMax = canvas.GetSliderMaxValue("Slider_HP");
             float life = (float)((sliderMax * ((int)currLife)) / playerMaxLife);
-            
+
             if ((life != canvas.GetSliderValue("Slider_HP")) && (canvas.GetSliderValue("Slider_HP") != -1))
             {
                 canvas.SetSliderValue((int)life, "Slider_HP");

--- a/TheOneScripting/UiScriptInventory.cs
+++ b/TheOneScripting/UiScriptInventory.cs
@@ -3,8 +3,7 @@
 public class UiScriptInventory : MonoBehaviour
 {
     public ICanvas canvas;
-    ItemManager itemManager;
-    IGameObject iManagerGO;
+
     UiManager menuManager;
 
     float cooldown = 0;
@@ -19,8 +18,6 @@ public class UiScriptInventory : MonoBehaviour
 
     public override void Start()
     {
-        iManagerGO = IGameObject.Find("ItemManager");
-        itemManager = iManagerGO.GetComponent<ItemManager>();
         menuManager = IGameObject.Find("UI_Manager").GetComponent<UiManager>();
 
         canvas.MoveSelectionButton(0 - canvas.GetSelectedButton());

--- a/TheOneScripting/UiScriptPause.cs
+++ b/TheOneScripting/UiScriptPause.cs
@@ -7,10 +7,6 @@ public class UiScriptPause : MonoBehaviour
     bool onCooldown = false;
 
     IGameObject playerGO;
-    PlayerScript player;
-
-    IGameObject GameManagerGO;
-    GameManager gameManager;
 
     UiManager menuManager;
 
@@ -22,12 +18,8 @@ public class UiScriptPause : MonoBehaviour
     public override void Start()
     {
         playerGO = IGameObject.Find("SK_MainCharacter");
-        player = playerGO.GetComponent<PlayerScript>();
 
         menuManager = IGameObject.Find("UI_Manager").GetComponent<UiManager>();
-
-        GameManagerGO = IGameObject.Find("GameManager");
-        gameManager = GameManagerGO.GetComponent<GameManager>();
 
         onCooldown = true;
 

--- a/TheOneScripting/UiScriptSettings.cs
+++ b/TheOneScripting/UiScriptSettings.cs
@@ -11,6 +11,8 @@ public class UiScriptSettings : MonoBehaviour
     IGameObject settingsControlsGO;
     IGameObject settingsDisplayGO;
 
+    ICanvas settingsDisCanvas;
+
     int currentButton = 0;
 
     public bool editing = false;
@@ -27,6 +29,8 @@ public class UiScriptSettings : MonoBehaviour
 
         canvas.MoveSelectionButton(0 - canvas.GetSelectedButton());
         currentButton = canvas.GetSelectedButton();
+
+        settingsDisCanvas = settingsDisplayGO.GetComponent<ICanvas>();
 
         settingsControlsGO.Disable();
         settingsDisplayGO.Disable();
@@ -61,11 +65,11 @@ public class UiScriptSettings : MonoBehaviour
 
         if (!onCooldown && editing && Input.GetKeyboardButton(Input.KeyboardCode.ESCAPE))
         {
-            settingsDisplayGO.GetComponent<ICanvas>().SetUiItemState(ICanvas.UiState.IDLE,"Checker_Vsync");
-            settingsDisplayGO.GetComponent<ICanvas>().SetUiItemState(ICanvas.UiState.IDLE,"Checker_Fullscreen");
-            settingsDisplayGO.GetComponent<ICanvas>().SetUiItemState(ICanvas.UiState.IDLE,"Slider_MainVolume");
-            settingsDisplayGO.GetComponent<ICanvas>().SetUiItemState(ICanvas.UiState.IDLE,"Slider_SFX");
-            settingsDisplayGO.GetComponent<ICanvas>().SetUiItemState(ICanvas.UiState.IDLE,"Slider_Music");
+            settingsDisCanvas.SetUiItemState(ICanvas.UiState.IDLE, "Checker_Vsync");
+            settingsDisCanvas.SetUiItemState(ICanvas.UiState.IDLE, "Checker_Fullscreen");
+            settingsDisCanvas.SetUiItemState(ICanvas.UiState.IDLE, "Slider_MainVolume");
+            settingsDisCanvas.SetUiItemState(ICanvas.UiState.IDLE, "Slider_SFX");
+            settingsDisCanvas.SetUiItemState(ICanvas.UiState.IDLE, "Slider_Music");
             editing = false;
         }
 
@@ -165,7 +169,7 @@ public class UiScriptSettings : MonoBehaviour
                     attachedGameObject.source.Play(IAudioSource.AudioEvent.UI_CLICK);
                     settingsControlsGO.Disable();
                     settingsDisplayGO.Disable();
-                    settingsDisplayGO.GetComponent<ICanvas>().SetUiItemState(ICanvas.UiState.HOVERED, "Checker_Vsync");
+                    settingsDisCanvas.SetUiItemState(ICanvas.UiState.HOVERED, "Checker_Vsync");
                     settingsDisplayGO.Enable();
                     editing = true;
                 }

--- a/TheOneScripting/UiScriptSettingsDisplay.cs
+++ b/TheOneScripting/UiScriptSettingsDisplay.cs
@@ -4,6 +4,8 @@ public class UiScriptSettingsDisplay : MonoBehaviour
 {
     public ICanvas canvas;
 
+    UiScriptSettings settingsScript;
+
     float cooldown = 0;
     bool onCooldown = false;
 
@@ -39,6 +41,8 @@ public class UiScriptSettingsDisplay : MonoBehaviour
         canvas.SetSliderValue(globalVolume, "Slider_MainVolume");
         canvas.SetSliderValue(sfxVolume, "Slider_SFX");
         canvas.SetSliderValue(musicVolume, "Slider_Music");
+
+        settingsScript = IGameObject.Find("Canvas_Settings").GetComponent<UiScriptSettings>();
     }
     public override void Update()
     {
@@ -60,7 +64,7 @@ public class UiScriptSettingsDisplay : MonoBehaviour
             onCooldown = false;
         }
 
-        if (IGameObject.Find("Canvas_Settings").GetComponent<UiScriptSettings>().editing)
+        if (settingsScript.editing)
         {
             //Input Updates
             if (!onCooldown)

--- a/TheOneScripting/UiScriptStats.cs
+++ b/TheOneScripting/UiScriptStats.cs
@@ -10,9 +10,6 @@ public class UiScriptStats : MonoBehaviour
     }
 
     public ICanvas canvas;
-    ItemManager itemManager;
-    IGameObject iManagerGO;
-    UiManager menuManager;
 
     int currency = 0;
 
@@ -37,10 +34,6 @@ public class UiScriptStats : MonoBehaviour
 
     public override void Start()
     {
-        iManagerGO = IGameObject.Find("ItemManager");
-        itemManager = iManagerGO.GetComponent<ItemManager>();
-        menuManager = IGameObject.Find("UI_Manager").GetComponent<UiManager>();
-
         canvas.MoveSelectionButton(0 - canvas.GetSelectedButton());
         currentButton = canvas.GetSelectedButton();
 
@@ -51,7 +44,7 @@ public class UiScriptStats : MonoBehaviour
 
         ChangeStatLvl(StatType.DAMAGE, false, playerDamageLvl);
         ChangeStatLvl(StatType.HEALTH, false, playerHealthLvl);
-        ChangeStatLvl(StatType.SPEED,  false, playerSpeedLvl);
+        ChangeStatLvl(StatType.SPEED, false, playerSpeedLvl);
 
 
         onCooldown = true;
@@ -164,7 +157,7 @@ public class UiScriptStats : MonoBehaviour
                     //this function only for canvas update, not stat !!!
                     ChangeStatLvl(StatType.DAMAGE);
                     onCooldown = true;
-                    currency = currency - 100;
+                    currency -= 100;
                     //PUT HERE FUNCTION TO BUY DAMAGE STAT UPGRADE
                     //PLAYER.CURRENCY = THIS.CURRENCY
                     //PLAYER.DAMAGELVL = THIS.PLAYERDAMAGELVL
@@ -177,7 +170,7 @@ public class UiScriptStats : MonoBehaviour
                     //this function only for canvas update, not stat !!!
                     ChangeStatLvl(StatType.HEALTH);
                     onCooldown = true;
-                    currency = currency - 100;
+                    currency -= 100;
                     //PUT HERE FUNCTION TO BUY HEALTH STAT UPGRADE
                     //PLAYER.CURRENCY = THIS.CURRENCY
                     //PLAYER.HEALTHLVL = THIS.PLAYERHEALTHLVL
@@ -190,7 +183,7 @@ public class UiScriptStats : MonoBehaviour
                     //this function only for canvas update, not stat !!!
                     ChangeStatLvl(StatType.SPEED);
                     onCooldown = true;
-                    currency = currency - 100;
+                    currency -= 100;
                     //PUT HERE FUNCTION TO BUY SPEED STAT UPGRADE
                     //PLAYER.CURRENCY = THIS.CURRENCY
                     //PLAYER.SPEEDLVL = THIS.PLAYERSPEEDLVL
@@ -211,26 +204,26 @@ public class UiScriptStats : MonoBehaviour
                 switch (newLvl)
                 {
                     case 1:
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,   "Button_DamageIconLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,   "Button_DamageLayerLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,   "Button_DamageArrowsLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.HOVERED,"Button_DamageIconLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.HOVERED,"Button_DamageLayerLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.HOVERED,"Button_DamageArrowsLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.HOVERED,"Button_DamageIconLvl3");
-                        canvas.SetUiItemState(ICanvas.UiState.HOVERED,"Button_DamageLayerLvl3");
-                        canvas.SetUiItemState(ICanvas.UiState.HOVERED,"Button_DamageArrowsLvl3");
-                        canvas.SetUiItemState(ICanvas.UiState.HOVERED,"Button_DamageIconLvl4");
-                        canvas.SetUiItemState(ICanvas.UiState.HOVERED,"Button_DamageLayerLvl4");
-                        canvas.SetUiItemState(ICanvas.UiState.HOVERED,"Button_DamageArrowsLvl4");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageIconLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageLayerLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageArrowsLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageIconLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageLayerLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageArrowsLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageIconLvl3");
+                        canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageLayerLvl3");
+                        canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageArrowsLvl3");
+                        canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageIconLvl4");
+                        canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageLayerLvl4");
+                        canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageArrowsLvl4");
                         break;
                     case 2:
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageIconLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageLayerLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageArrowsLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageIconLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageLayerLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageArrowsLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageIconLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageLayerLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageArrowsLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageIconLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageLayerLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageArrowsLvl2");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageIconLvl3");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageLayerLvl3");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageArrowsLvl3");
@@ -239,15 +232,15 @@ public class UiScriptStats : MonoBehaviour
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageArrowsLvl4");
                         break;
                     case 3:
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageIconLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageLayerLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageArrowsLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageIconLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageLayerLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageArrowsLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageIconLvl3");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageLayerLvl3");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_DamageArrowsLvl3");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageIconLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageLayerLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageArrowsLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageIconLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageLayerLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageArrowsLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageIconLvl3");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageLayerLvl3");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_DamageArrowsLvl3");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageIconLvl4");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageLayerLvl4");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_DamageArrowsLvl4");
@@ -276,9 +269,9 @@ public class UiScriptStats : MonoBehaviour
                 switch (newLvl)
                 {
                     case 1:
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthIconLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthLayerLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthArrowsLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthIconLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthLayerLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthArrowsLvl1");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_HealthIconLvl2");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_HealthLayerLvl2");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_HealthArrowsLvl2");
@@ -290,12 +283,12 @@ public class UiScriptStats : MonoBehaviour
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_HealthArrowsLvl4");
                         break;
                     case 2:
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthIconLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthLayerLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthArrowsLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthIconLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthLayerLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthArrowsLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthIconLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthLayerLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthArrowsLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthIconLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthLayerLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthArrowsLvl2");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_HealthIconLvl3");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_HealthLayerLvl3");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_HealthArrowsLvl3");
@@ -304,15 +297,15 @@ public class UiScriptStats : MonoBehaviour
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_HealthArrowsLvl4");
                         break;
                     case 3:
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthIconLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthLayerLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthArrowsLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthIconLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthLayerLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthArrowsLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthIconLvl3");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthLayerLvl3");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_HealthArrowsLvl3");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthIconLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthLayerLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthArrowsLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthIconLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthLayerLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthArrowsLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthIconLvl3");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthLayerLvl3");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_HealthArrowsLvl3");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_HealthIconLvl4");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_HealthLayerLvl4");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_HealthArrowsLvl4");
@@ -341,9 +334,9 @@ public class UiScriptStats : MonoBehaviour
                 switch (newLvl)
                 {
                     case 1:
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedIconLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedLayerLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedArrowsLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedIconLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedLayerLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedArrowsLvl1");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedIconLvl2");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedLayerLvl2");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedArrowsLvl2");
@@ -353,36 +346,36 @@ public class UiScriptStats : MonoBehaviour
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedIconLvl4");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedLayerLvl4");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedArrowsLvl4");
-                        break; 
-                    case 2:    
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedIconLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedLayerLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedArrowsLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedIconLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedLayerLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedArrowsLvl2");
+                        break;
+                    case 2:
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedIconLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedLayerLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedArrowsLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedIconLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedLayerLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedArrowsLvl2");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedIconLvl3");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedLayerLvl3");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedArrowsLvl3");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedIconLvl4");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedLayerLvl4");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedArrowsLvl4");
-                        break; 
-                    case 3:    
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedIconLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedLayerLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedArrowsLvl1");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedIconLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedLayerLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedArrowsLvl2");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedIconLvl3");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedLayerLvl3");
-                        canvas.SetUiItemState(ICanvas.UiState.IDLE,    "Button_SpeedArrowsLvl3");
+                        break;
+                    case 3:
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedIconLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedLayerLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedArrowsLvl1");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedIconLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedLayerLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedArrowsLvl2");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedIconLvl3");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedLayerLvl3");
+                        canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedArrowsLvl3");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedIconLvl4");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedLayerLvl4");
                         canvas.SetUiItemState(ICanvas.UiState.HOVERED, "Button_SpeedArrowsLvl4");
                         break;
-                    case 4:   
+                    case 4:
                         canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedIconLvl1");
                         canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedLayerLvl1");
                         canvas.SetUiItemState(ICanvas.UiState.IDLE, "Button_SpeedArrowsLvl1");

--- a/TheOneScripting/WhiteXenomorphBehaviour.cs
+++ b/TheOneScripting/WhiteXenomorphBehaviour.cs
@@ -19,20 +19,19 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
     }
 
     IGameObject playerGO;
-    Vector3 directorVector;
     float playerDistance;
 
     // White Xenomorph parameters
     float life = 200.0f;
-    float movementSpeed = 20.0f * 3;
+    readonly float movementSpeed = 20.0f * 3;
     States currentState = States.Idle;
     States lastState = States.Idle;
     WhiteXenomorphAttacks currentAttack = WhiteXenomorphAttacks.None;
-    Vector3 initialPos;
+    readonly Vector3 initialPos;
 
     // Patrol
-    float patrolRange = 100;
-    float patrolSpeed = 20.0f;
+    readonly float patrolRange = 100;
+    readonly float patrolSpeed = 20.0f;
     float roundProgress = 0.0f; //Do not modify
     bool goingToRoundPos = false;
 
@@ -65,8 +64,8 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
         gameManager = IGameObject.Find("GameManager").GetComponent<GameManager>();
 
         attachedGameObject.animator.Play("Walk");
-        attachedGameObject.animator.blend = false;
-        attachedGameObject.animator.transitionTime = 0.0f;
+        attachedGameObject.animator.Blend = false;
+        attachedGameObject.animator.TransitionTime = 0.0f;
 
         acidSpitPSGO = attachedGameObject.FindInChildren("AcidSpitPS");
         tailAttackPSGO = attachedGameObject.FindInChildren("TailAttackPS");
@@ -82,8 +81,7 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
         if (attachedGameObject.transform.ComponentCheck())
         {
             //Set the director vector and distance to the player
-            directorVector = (playerGO.transform.position - attachedGameObject.transform.position).Normalize();
-            playerDistance = Vector3.Distance(playerGO.transform.position, attachedGameObject.transform.position);
+            playerDistance = Vector3.Distance(playerGO.transform.Position, attachedGameObject.transform.Position);
 
             UpdateFSMStates();
             DoStateBehaviour();
@@ -96,7 +94,7 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
     {
         if (life <= 0) { currentState = States.Dead; return; }
 
-        if (!detected && playerDistance < detectedRange) 
+        if (!detected && playerDistance < detectedRange)
         {
             detected = true;
             currentState = States.Chase;
@@ -104,7 +102,7 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
 
         if (detected)
         {
-            attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+            attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
             if (playerDistance < isCloseRange && !isClose)
             {
                 isClose = true;
@@ -146,7 +144,7 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
                 return;
             case States.Attack:
                 player.isFighting = true;
-                attachedGameObject.transform.LookAt2D(playerGO.transform.position);
+                attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
                 ChooseAttack();
 
                 switch (currentAttack)
@@ -164,15 +162,15 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
                 break;
             case States.Chase:
                 player.isFighting = true;
-                attachedGameObject.transform.LookAt2D(playerGO.transform.position);
-                attachedGameObject.transform.Translate(attachedGameObject.transform.forward * movementSpeed * Time.deltaTime);
+                attachedGameObject.transform.LookAt2D(playerGO.transform.Position);
+                attachedGameObject.transform.Translate(attachedGameObject.transform.Forward * movementSpeed * Time.deltaTime);
                 break;
             case States.Patrol:
                 Patrol();
                 break;
             case States.Dead:
                 attachedGameObject.animator.Play("Death");
-                if (deathPSGO != null) deathPSGO.GetComponent<IParticleSystem>().Play();
+                deathPSGO?.GetComponent<IParticleSystem>().Play();
                 break;
             default:
                 break;
@@ -188,14 +186,14 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
                 currentAttack = WhiteXenomorphAttacks.ClawAttack;
                 attachedGameObject.animator.Play("TailAttack");
 
-                if (tailAttackPSGO != null) tailAttackPSGO.GetComponent<IParticleSystem>().Play();
+                tailAttackPSGO?.GetComponent<IParticleSystem>().Play();
             }
             else
             {
                 currentAttack = WhiteXenomorphAttacks.TailTrip;
                 attachedGameObject.animator.Play("Spit");
 
-                if (acidSpitPSGO != null) acidSpitPSGO.GetComponent<IParticleSystem>().Play();
+                acidSpitPSGO?.GetComponent<IParticleSystem>().Play();
             }
             //Debug.Log("Chestburster current attack: " + currentAttack);
         }
@@ -204,7 +202,7 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
     private void ClawAttack()
     {
         //InternalCalls.InstantiateBullet(attachedGameObject.transform.position + attachedGameObject.transform.forward * 12.5f, attachedGameObject.transform.rotation);
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             ResetState();
         }
@@ -212,7 +210,7 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
 
     private void TailTrip()
     {
-        if (attachedGameObject.animator.currentAnimHasFinished)
+        if (attachedGameObject.animator.CurrentAnimHasFinished)
         {
             ResetState();
         }
@@ -261,9 +259,9 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
     private bool MoveTo(Vector3 targetPosition)
     {
         //Return true if arrived at destination
-        if (Vector3.Distance(attachedGameObject.transform.position, targetPosition) < 0.5f) return true;
+        if (Vector3.Distance(attachedGameObject.transform.Position, targetPosition) < 0.5f) return true;
 
-        Vector3 dirVector = (targetPosition - attachedGameObject.transform.position).Normalize();
+        Vector3 dirVector = (targetPosition - attachedGameObject.transform.Position).Normalize();
         attachedGameObject.transform.Translate(dirVector * movementSpeed * Time.deltaTime);
 
         return false;
@@ -276,12 +274,12 @@ public class WhiteXenomorphBehaviour : MonoBehaviour
         {
             if (!detected)
             {
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, detectedRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, detectedRange, new Vector3(1.0f, 0.8f, 0.0f)); //Yellow
             }
             else
             {
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, isCloseRange, new Vector3(1.0f, 0.0f, 0.0f)); //Red
-                Debug.DrawWireCircle(attachedGameObject.transform.position + Vector3.up * 4, maxChasingRange, new Vector3(1.0f, 0.0f, 1.0f)); //Purple
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, isCloseRange, new Vector3(1.0f, 0.0f, 0.0f)); //Red
+                Debug.DrawWireCircle(attachedGameObject.transform.Position + Vector3.up * 4, maxChasingRange, new Vector3(1.0f, 0.0f, 1.0f)); //Purple
             }
         }
     }


### PR DESCRIPTION
- Changed all Find calls in scripts used in MainMenu and L1R1 to make them in the Start function of the behaviours
- Changed all GetComponent calls in scripts used in MainMenu and L1R1 to make them in the Start function of the behaviours
- Changed variables in scripts to readonly when necessary
- Removed not used variables from scripts
- Changed function names that didn't follow nomenclature (start with Caps) in the IAnimator and ITransform script
- Formatted all scripts

- Changed getComponent calls in monoregisterer and put them outside loops
- Tried putting tostring calls in hud script outside the textString calls, didnt fix
- Problem most likely comes from the textString in HUD script, removing the calls that contain toString from the script makes the crash not occur before the 15 minute mark (didnt test further)

- Commented ToString in HUD script, now L1R1 executes indifinitely while AFK
- Changed ammo to int (was float)